### PR TITLE
[#3] Feat: 소비기록 엔티티 설정

### DIFF
--- a/src/main/java/com/server/money_touch/MoneyTouchApplication.java
+++ b/src/main/java/com/server/money_touch/MoneyTouchApplication.java
@@ -2,8 +2,10 @@ package com.server.money_touch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MoneyTouchApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/money_touch/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/consumptionRecord/entity/ConsumptionRecord.java
@@ -1,0 +1,29 @@
+package com.server.money_touch.consumptionRecord.entity;
+
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class ConsumptionRecord extends BaseEntity {
+
+    @Column(nullable = false)
+    private int amount;
+
+    @Column(length = 20, nullable = false)
+    private String content;
+
+    private boolean isPublic = true;
+
+    private String imageUrl;
+
+    @Column(length = 1000)
+    private String memo;
+
+
+}

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/BaseEntity.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.server.money_touch.global.apiPayload.code;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #3 

## 📝 작업 내용

- 소비기록 엔티티(항목, 비용, 피드 노출 여부, 이미지, 메모), BaseEntity(id, 생성/수정일자) 생성

## 📌 공유 사항

-  id, 생성/수정일자 쓰는 테이블이 많은 것 같아 BaseEntity 만들었습니다. 
- 만약 본인 엔티티가 생성/수정일자를 사용하지 않는 다면 굳이 상속하지 않아도 됩니다. 
- BaseEntity 는 apiPayLoad/code 폴더에 있고, ConsumptionRecord.java 를 참고하시면 됩니다.
- Labels 는 마땅한 게 없는 것 같아 feature 로 했습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

