### PR TITLE
[#9] Feat: 피드 + 배지 관련 엔터티 설정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/badge/entity/Badge.java
+++ b/src/main/java/com/server/money_touch/domain/badge/entity/Badge.java
@@ -1,0 +1,25 @@
+package com.server.money_touch.domain.badge.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Badge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+
+}

--- a/src/main/java/com/server/money_touch/domain/badge/entity/UserBadge.java
+++ b/src/main/java/com/server/money_touch/domain/badge/entity/UserBadge.java
@@ -1,0 +1,20 @@
+package com.server.money_touch.domain.badge.entity;
+
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class UserBadge extends BaseEntity {
+
+    // 유저 관계 매핑
+
+    // 배지 관계 매핑
+
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Comment.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Comment.java
@@ -1,0 +1,42 @@
+package com.server.money_touch.domain.consumptionRecord.entity;
+
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Comment extends BaseEntity {
+
+    // 소비기록 외래키 연결
+
+    // 대댓글을 위한 부모 댓글 id , null 이면 일반 댓글
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    @ColumnDefault("0")
+    private Integer likes = 0;
+
+    // 자식 댓글 일대다 관계
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> replies = new ArrayList<>();
+
+    // 양방향 연관관계
+    public void setParent(Comment parent) {
+        this.parent = parent;
+        if (parent != null) {
+            parent.getReplies().add(this);
+        }
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -35,7 +35,7 @@ public class ConsumptionRecord extends BaseEntity {
 
     @Column(length = 1000)
     private String memo;
-
+    
     @ColumnDefault("0")
     private Integer commentCount = 0;
 

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -6,6 +6,7 @@ import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -35,5 +36,15 @@ public class ConsumptionRecord extends BaseEntity {
     @Column(length = 1000)
     private String memo;
 
+    @ColumnDefault("0")
+    private Integer commentCount = 0;
 
+    @ColumnDefault("0")
+    private Integer wiseCount = 0;
+
+    @ColumnDefault("0")
+    private Integer wasteCount = 0;
+
+    @ColumnDefault("0")
+    private Integer viewCount = 0;
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Reaction.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Reaction.java
@@ -1,6 +1,6 @@
 package com.server.money_touch.domain.consumptionRecord.entity;
 
-import com.server.money_touch.consumptionRecord.enums.ReactionType;
+import com.server.money_touch.domain.consumptionRecord.enums.ReactionType;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Reaction.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Reaction.java
@@ -1,0 +1,25 @@
+package com.server.money_touch.domain.consumptionRecord.entity;
+
+import com.server.money_touch.consumptionRecord.enums.ReactionType;
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Reaction extends BaseEntity {
+
+    // 유저 관계 매핑
+
+    // 소비기록 관계 매핑
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReactionType type;
+
+}
+

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/enums/ReactionType.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/enums/ReactionType.java
@@ -1,0 +1,5 @@
+package com.server.money_touch.domain.consumptionRecord.enums;
+
+public enum ReactionType {
+    WISE, WASTE
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #9 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 피드 관련 엔터티
    - `ConsumptionRecord` 엔터티에 `commentCount, wiseCount, wasteCount, viewCount` 필드 추가
    - `Reaction` 엔터티 - 유저, 소비기록 관계 매핑 예정 
    - `ReactionType Enums` 설정
    - `Comment` 엔터티
        - 대댓글을 위한 Self Join 
- 배지 관련 엔터티
    - `Badge` 엔터티 - 배지 종류
    - `UserBadge` 엔터티 - 유저가 획득한 배지

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  피드 관련된 Reaction과 Comment 엔터티를 따로 Feed 라는 패키지를 만들어 그 아래 둘까 고민을 했는데, 피드도 소비기록중 하나이기에 일단 ConsumptionRecord 패키지 안에 두었습니다 (혹시 따로 빼는게 관리하기에 나을까요..??)

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?
