### PR TITLE
[#15] 피드 + 배지 + 알림 연관관계 매핑 설정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/badge/entity/UserBadge.java
+++ b/src/main/java/com/server/money_touch/domain/badge/entity/UserBadge.java
@@ -1,8 +1,8 @@
 package com.server.money_touch.domain.badge.entity;
 
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -13,8 +13,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class UserBadge extends BaseEntity {
 
-    // 유저 관계 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    // 배지 관계 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id", nullable = false)
+    private Badge badge;
 
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Comment.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.consumptionRecord.entity;
 
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -15,7 +16,13 @@ import java.util.List;
 @EntityListeners(AuditingEntityListener.class)
 public class Comment extends BaseEntity {
 
-    // 소비기록 외래키 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumption_record_id", nullable = false)
+    private ConsumptionRecord consumptionRecord;
 
     // 대댓글을 위한 부모 댓글 id , null 이면 일반 댓글
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Reaction.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Reaction.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.consumptionRecord.entity;
 
 import com.server.money_touch.domain.consumptionRecord.enums.ReactionType;
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -11,11 +12,18 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "consumption_record_id"})
+}) // 한 유저는 한 피드당 하나의 리액션만 가능
 public class Reaction extends BaseEntity {
 
-    // 유저 관계 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    // 소비기록 관계 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumption_record_id", nullable = false)
+    private ConsumptionRecord consumptionRecord;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
+++ b/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.notification.entity;
 
 
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -13,6 +14,17 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Notification extends BaseEntity {
 
+    // 알림 수신자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 알림 유형
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_type_id", nullable = false)
+    private NotificationType notificationType;
+
+    // 알림 발신자
     @Column(nullable = false)
     private Long senderId;
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #15 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 피드 관련 엔터티
    - 공감 엔터티 - `user_id, consumption_record_id` 매핑
    - 댓글 엔터티 - `user_id, consumption_record_id` 매핑
- 알림 관련 엔터티
    - 알림 엔터티 - `user_id, notification_type_id` 매핑
- 배지 관련 엔터티
    - 유저가 획득한 배지 엔터티 - `user_id, badge_id` 매핑  

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  여러 컬럼에 대해 UNIQUE 제약조건을 설정하는 방법에서 `@UniqueConstraint`이 있다 하여 Reaction 엔터티에 추가를 해보았습니다. 해당 코드는 한 유저는 한 피드당 하나의 리액션만 가능하게 하는 것입니다. 이런 로직은 서비스단에서도 처리할 수 있는 것으로 알고 있는데 굳이 이 코드는 불필요 한것일까요..?? 다른분들은 평소에 어떻게 설정하시는지 궁금합니다 !
```
@Table(uniqueConstraints = {
        @UniqueConstraint(columnNames = {"user_id", "consumption_record_id"})
})
```

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

