### PR TITLE
✨[Feat] 가계부 관련 엔티티 연관관계 매핑 및 예산 엔티티 구조 변경

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/entity/Budget.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/Budget.java
@@ -1,8 +1,8 @@
 package com.server.money_touch.domain.budget.entity;
 
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -19,4 +19,7 @@ public class Budget extends BaseEntity {
     private Boolean isFromRoutine = false;
 
     // 예산-유저 다대일 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
@@ -1,6 +1,6 @@
 package com.server.money_touch.domain.budget.entity;
 
-import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
@@ -10,15 +10,6 @@ import lombok.*;
 @AllArgsConstructor
 @Entity
 public class BudgetCategory extends BaseEntity {
-    // 예산 카테고리 이름: 배달/외식, 교통비 등
-    @Column(length = 8, nullable = false)
-    private String budgetCategoryName;
-
-    // 예산 카테고리 타입: 기본 카테고리 / 내 카테고리 / 소비 루틴 카테고리
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private CategoryType budgetCategoryType;
-
     @Column(columnDefinition = "INT DEFAULT 0", nullable = false)
     private Integer budgetCategoryMoney; // 예산 카테고리 금액
 
@@ -26,4 +17,9 @@ public class BudgetCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "budget_id")
     private Budget budget;
+
+    // 카테고리별 예산-소비 카테고리 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumption_category_id")
+    private ConsumptionCategory consumptionCategory;
 }

--- a/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.budget.entity;
 
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/server/money_touch/domain/budget/entity/ConsumptionCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/ConsumptionCategory.java
@@ -1,0 +1,25 @@
+package com.server.money_touch.domain.budget.entity;
+
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class ConsumptionCategory extends BaseEntity {
+    // 예산 카테고리 이름: 배달/외식, 교통비 등
+    @Column(length = 8, nullable = false)
+    private String budgetCategoryName;
+
+    // 예산 카테고리 타입: 기본 카테고리 / 내 카테고리 / 소비 루틴 카테고리
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CategoryType budgetCategoryType;
+}

--- a/src/main/java/com/server/money_touch/domain/budget/entity/ConsumptionCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/ConsumptionCategory.java
@@ -1,11 +1,9 @@
 package com.server.money_touch.domain.budget.entity;
 
 import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -22,4 +20,9 @@ public class ConsumptionCategory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CategoryType budgetCategoryType;
+
+    // 소비 카테고리-유저 다대일 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/server/money_touch/domain/budget/enums/CategoryType.java
+++ b/src/main/java/com/server/money_touch/domain/budget/enums/CategoryType.java
@@ -1,4 +1,4 @@
-package com.server.money_touch.domain.budget.entity;
+package com.server.money_touch.domain.budget.enums;
 
 public enum CategoryType {
     DEFAULT("기본 카테고리"),

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
@@ -1,4 +1,4 @@
-package com.server.money_touch.domain.budget.entity;
+package com.server.money_touch.domain.consumptionRecord.entity;
 
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.user.entity.User;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -1,6 +1,5 @@
 package com.server.money_touch.domain.consumptionRecord.entity;
 
-import com.server.money_touch.domain.budget.entity.ConsumptionCategory;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -1,6 +1,6 @@
 package com.server.money_touch.domain.consumptionRecord.entity;
 
-import com.server.money_touch.domain.budget.entity.BudgetCategory;
+import com.server.money_touch.domain.budget.entity.ConsumptionCategory;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
@@ -20,8 +20,8 @@ public class ConsumptionRecord extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "budget_category_id", nullable = false)
-    private BudgetCategory budgetCategory;
+    @JoinColumn(name = "consumption_category_id", nullable = false)
+    private ConsumptionCategory consumptionCategory;
 
     @Column(nullable = false)
     private int amount;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/TotalConsumption.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/TotalConsumption.java
@@ -1,8 +1,8 @@
 package com.server.money_touch.domain.consumptionRecord.entity;
 
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -15,4 +15,7 @@ public class TotalConsumption extends BaseEntity {
     private Integer totalConsumptionAmount; // 총 소비 금액
 
     // 총 소비-유저 다대일 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.fixedConsumption.entity;
 
 import com.server.money_touch.domain.budget.entity.BudgetCategory;
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,6 +20,11 @@ public class FixedConsumption extends BaseEntity {
 
     @Column(nullable = false, length = 1000)
     private String fixedConsumptionMemo;
+
+    // 고정비-유저 다대일 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     // 고정비-카테고리별 예산 다대일
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.routine.entity;
 
 import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,4 +30,7 @@ public class Routine extends BaseEntity {
     private Budget budget;
 
     // 소비루틴-유저 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> - #17 

## 📝 작업 내용
1. **예산, 소비 카테고리, 카테고리별 예산 엔티티 구조 변경**
  기존에는 `BudgetCategory`에 소비 카테고리 이름(배달/외식, 교육비 등)과 타입(enum, 기본 카테고리, 내 카테고리, 소비 루틴 카테고리)을 함께 저장했지만,  
  소비 기록에서 소비 카테고리 이름을 참조하기에 구조가 복잡한 것 같아 다음과 같이 분리했습니다:
  
  - `Budget`: 예산 총합
  - `ConsumptionCategory`: 소비 카테고리 (이름, 타입 포함)
  - `BudgetCategory`: 예산과 소비 카테고리 연결, 소비 카테고리별 예산 금액 저장
  
  소비 기록 테이블은 `ConsumptionCategory`를 참조하도록 변경했습니다.

2. **예산, 소비 카테고리, 소비 루틴, 총 소비, 고정비 엔티티 유저와 연관관계 연결**

## 📌 공유 사항
<img width="1008" alt="스크린샷 2025-07-06 오후 4 36 11" src="https://github.com/user-attachments/assets/8afb95e8-668c-4915-a1c9-5ce85e1a25fd" />
&nbsp;
정확한 예산, 소비 카테고리, 카테고리별 예산 엔티티 구조는 ERD 참고해주세요!

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 💬 리뷰 요구사항 (선택)
> 수정한 예산 및 소비 카테고리 구조가, 기존 방식보다 소비 엔티티에서 참조하기 구조적으로 더 나을지 궁금합니다..
