### PR TITLE
✨[Feat] 가계부 예산&고정비&소비 루틴 관련 API 명세서 작성

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/budget")
+@RequestMapping("/api/budgets")
 public class BudgetController {
 
     // 가계부 한 달 예산 등록
@@ -95,12 +95,14 @@ public class BudgetController {
 
     // 한 달 예산 대비 총 소비 사용 금액 조회
     @Operation(
-            summary = "가계부 한 달 총 소비 금액 조회 API",
-            description = "한 달 예산 기준으로 현재까지의 총 소비 금액과 예산 소진 비율을 반환합니다."
+            summary = "한 달 총 소비 금액 조회 API",
+            description = "한 달 예산을 기준으로 예산 아이디 및 현재까지의 총 소비 금액과 예산 소진 비율을 반환합니다. " +
+                    "등록된 예산이 없는 경우, 에러 메시지를 반환합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.TotalConsumptionResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })

--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -76,7 +76,7 @@ public class BudgetController {
             summary = "한 달 예산 내역 조회 API",
             description = "아이디와 일치하는 한 달 예산 내역(에산 수정, 소비 루틴 등록 시) 조회 API 입니다."
     )
-    @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetDetailDTO.class)
+//    @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetDetailDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),

--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -42,6 +42,7 @@ public class BudgetController {
         return ApiResponse.onSuccess(response);
     }
 
+
     // 가계부 한 달 예산 수정 (타인의 소비 루틴 가져올 시 사용)
     @Operation(
             summary = "한 달 예산 수정 API",
@@ -60,6 +61,7 @@ public class BudgetController {
         BudgetResponse.BudgetCreateResultDTO response = BudgetResponse.BudgetCreateResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
+
 
     // 가계부 한 달 예산 대비 총 소비 사용 금액 조회
     @Operation(

--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -8,6 +8,8 @@ import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -43,29 +45,57 @@ public class BudgetController {
     }
 
 
-    // 가계부 한 달 예산 수정 (타인의 소비 루틴 가져올 시 사용)
+    // 한 달 예산 수정
     @Operation(
             summary = "한 달 예산 수정 API",
-            description = "총 예산과 카테고리별(기본, 사용자 정의, 소비 루틴) 예산 목록을 RequestBody로 입력받아 한 달 예산을 수정합니다."
+            description = "아이디와 일치하는 한 달 예산 수정 API 입니다. " +
+                    "총 예산과 카테고리별(기본, 사용자 정의, 소비 루틴) 예산 목록을 RequestBody로 입력받아 한 달 예산을 수정합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetCreateResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
-    @PatchMapping()
-    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> patchBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request) {
+    @Parameters({
+            @Parameter(name = "budgetId", description = "수정하려는 예산 아이디", example = "1", required = true),
+    })
+    @PatchMapping("/{budgetId}")
+    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> patchBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
+                                                                         @RequestParam Long budgetId) {
         BudgetResponse.BudgetCreateResultDTO response = BudgetResponse.BudgetCreateResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 
 
-    // 가계부 한 달 예산 대비 총 소비 사용 금액 조회
+    // 한 달 예산 내역 조회
     @Operation(
-            summary = "한 달 예산 대비 총 소비 금액 조회 API",
+            summary = "한 달 예산 내역 조회 API",
+            description = "아이디와 일치하는 한 달 예산 내역(에산 수정, 소비 루틴 등록 시) 조회 API 입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetDetailDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "budgetId", description = "조회하려는 예산 아이디", example = "1", required = true),
+    })
+    @GetMapping("/{budgetId}")
+    public ApiResponse<BudgetResponse.BudgetDetailDTO> getBudget(@RequestParam Long budgetId) {
+        BudgetResponse.BudgetDetailDTO response = BudgetResponse.BudgetDetailDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    // 한 달 예산 대비 총 소비 사용 금액 조회
+    @Operation(
+            summary = "가계부 한 달 총 소비 금액 조회 API",
             description = "한 달 예산 기준으로 현재까지의 총 소비 금액과 예산 소진 비율을 반환합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.TotalConsumptionResultDTO.class)

--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -65,7 +65,7 @@ public class BudgetController {
     })
     @PatchMapping("/{budgetId}")
     public ApiResponse<BudgetResponse.BudgetCreateResultDTO> patchBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
-                                                                         @RequestParam Long budgetId) {
+                                                                         @PathVariable Long budgetId) {
         BudgetResponse.BudgetCreateResultDTO response = BudgetResponse.BudgetCreateResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
@@ -87,7 +87,7 @@ public class BudgetController {
             @Parameter(name = "budgetId", description = "조회하려는 예산 아이디", example = "1", required = true),
     })
     @GetMapping("/{budgetId}")
-    public ApiResponse<BudgetResponse.BudgetDetailDTO> getBudget(@RequestParam Long budgetId) {
+    public ApiResponse<BudgetResponse.BudgetDetailDTO> getBudget(@PathVariable Long budgetId) {
         BudgetResponse.BudgetDetailDTO response = BudgetResponse.BudgetDetailDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -25,8 +25,8 @@ public class BudgetController {
 
     // 가계부 한 달 예산 등록
     @Operation(
-            summary = "가계부 한 달 예산 등록 API",
-            description = "가계부 한 달 예산 등록 API 입니다."
+            summary = "한 달 예산 등록 API",
+            description = "총 예산과 카테고리별(기본, 사용자 정의, 소비 루틴) 예산 목록을 RequestBody로 입력받아 한 달 예산을 등록합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetCreateResultDTO.class)
     @ApiErrorCodeExamples({
@@ -38,7 +38,43 @@ public class BudgetController {
     })
     @PostMapping()
     public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request) {
-        BudgetResponse.BudgetCreateResultDTO response = null;
+        BudgetResponse.BudgetCreateResultDTO response = BudgetResponse.BudgetCreateResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 가계부 한 달 예산 수정 (타인의 소비 루틴 가져올 시 사용)
+    @Operation(
+            summary = "한 달 예산 수정 API",
+            description = "총 예산과 카테고리별(기본, 사용자 정의, 소비 루틴) 예산 목록을 RequestBody로 입력받아 한 달 예산을 수정합니다."
+    )
+    @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetCreateResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @PatchMapping()
+    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> patchBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request) {
+        BudgetResponse.BudgetCreateResultDTO response = BudgetResponse.BudgetCreateResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 가계부 한 달 예산 대비 총 소비 사용 금액 조회
+    @Operation(
+            summary = "한 달 예산 대비 총 소비 금액 조회 API",
+            description = "한 달 예산 기준으로 현재까지의 총 소비 금액과 예산 소진 비율을 반환합니다."
+    )
+    @ApiSuccessCodeExample(resultClass = BudgetResponse.TotalConsumptionResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @GetMapping("/total-consumption")
+    public ApiResponse<BudgetResponse.TotalConsumptionResultDTO> getTotalConsumption() {
+        BudgetResponse.TotalConsumptionResultDTO response = BudgetResponse.TotalConsumptionResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetRequest.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetRequest.java
@@ -5,12 +5,16 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 public class BudgetRequest {
 
     @Getter
+    @Setter
+    @NoArgsConstructor
     @Schema(description = "한 달 예산 등록 요청 정보")
     public static class BudgetCreateDTO {
 
@@ -32,6 +36,8 @@ public class BudgetRequest {
         private List<RoutineCategoryBudget> routineCategoryBudgets;
 
         @Getter
+        @Setter
+        @NoArgsConstructor
         @Schema(description = "기본 카테고리별 예산")
         public static class DefaultCategoryBudget {
 
@@ -46,6 +52,8 @@ public class BudgetRequest {
         }
 
         @Getter
+        @Setter
+        @NoArgsConstructor
         @Schema(description = "사용자 정의 카테고리별 예산")
         public static class CustomCategoryBudget {
 
@@ -60,6 +68,8 @@ public class BudgetRequest {
         }
 
         @Getter
+        @Setter
+        @NoArgsConstructor
         @Schema(description = "소비 루틴 카테고리 예산")
         public static class RoutineCategoryBudget {
 

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -43,28 +43,13 @@ public class BudgetResponse {
         @Schema(description = "한 달 전체 예산", example = "500000")
         private Integer totalBudget;
 
-        @Schema(description = "기본 카테고리별 예산 목록", example = "  \"defaultCategoryBudgets\": [\n" +
-                "    {\n" +
-                "      \"categoryName\": \"배달/외식\",\n" +
-                "      \"amount\": 100000\n" +
-                "    }\n" +
-                "  ]")
+        @Schema(description = "기본 카테고리별 예산 목록")
         private List<BudgetResponse.BudgetDetailDTO.DefaultCategoryBudget> defaultCategoryBudgets;
 
-        @Schema(description = "내 카테고리별 예산 목록", example = "  \"customCategoryBudgets\": [\n" +
-                "    {\n" +
-                "      \"categoryName\": \"교육비\",\n" +
-                "      \"amount\": 150000\n" +
-                "    }\n" +
-                "  ],")
+        @Schema(description = "내 카테고리별 예산 목록")
         private List<BudgetResponse.BudgetDetailDTO.CustomCategoryBudget> customCategoryBudgets;
 
-        @Schema(description = "소비 루틴 카테고리 예산 목록", example = "  \"routineCategoryBudgets\": [\n" +
-                "    {\n" +
-                "      \"categoryName\": \"술/유흥\",\n" +
-                "      \"amount\": 100000\n" +
-                "    }\n" +
-                "  ]")
+        @Schema(description = "소비 루틴 카테고리 예산 목록")
         private List<BudgetResponse.BudgetDetailDTO.RoutineCategoryBudget> routineCategoryBudgets;
 
         @Builder

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -1,10 +1,9 @@
 package com.server.money_touch.domain.budget.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.List;
 
 public class BudgetResponse {
 
@@ -29,5 +28,79 @@ public class BudgetResponse {
 
         @Schema(description = "한 달 예산 대비 총 소비 금액 퍼센트", example = "50")
         private Integer percent;
+    }
+
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "한 달 예산 내역 응답 정보")
+    public static class BudgetDetailDTO {
+
+        @Schema(description = "한 달 전체 예산", example = "500000")
+        private Integer totalBudget;
+
+        @Schema(description = "기본 카테고리별 예산 목록", example = "  \"defaultCategoryBudgets\": [\n" +
+                "    {\n" +
+                "      \"categoryName\": \"배달/외식\",\n" +
+                "      \"amount\": 100000\n" +
+                "    }\n" +
+                "  ]")
+        private List<BudgetRequest.BudgetCreateDTO.DefaultCategoryBudget> defaultCategoryBudgets;
+
+        @Schema(description = "내 카테고리별 예산 목록", example = "  \"customCategoryBudgets\": [\n" +
+                "    {\n" +
+                "      \"categoryName\": \"교육비\",\n" +
+                "      \"amount\": 150000\n" +
+                "    }\n" +
+                "  ],")
+        private List<BudgetRequest.BudgetCreateDTO.CustomCategoryBudget> customCategoryBudgets;
+
+        @Schema(description = "소비 루틴 카테고리 예산 목록", example = "  \"routineCategoryBudgets\": [\n" +
+                "    {\n" +
+                "      \"categoryName\": \"술/유흥\",\n" +
+                "      \"amount\": 100000\n" +
+                "    }\n" +
+                "  ]")
+        private List<BudgetRequest.BudgetCreateDTO.RoutineCategoryBudget> routineCategoryBudgets;
+
+        @Builder
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Schema(description = "기본 카테고리별 예산")
+        public static class DefaultCategoryBudget {
+            @Schema(description = "기본 예산 카테고리명", example = "배달/외식")
+            private String categoryName;
+
+            @Schema(description = "카테고리별 예산 금액", example = "100000")
+            private Integer amount;
+        }
+
+        @Builder
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Schema(description = "사용자 정의 카테고리별 예산")
+        public static class CustomCategoryBudget {
+            @Schema(description = "사용자 정의 카테고리명", example = "교육비")
+            private String categoryName;
+
+            @Schema(description = "카테고리별 예산 금액", example = "150000")
+            private Integer amount;
+        }
+
+        @Builder
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Schema(description = "소비 루틴 카테고리 예산")
+        public static class RoutineCategoryBudget {
+            @Schema(description = "소비 루틴 카테고리명", example = "술/유흥")
+            private String categoryName;
+
+            private Integer amount;
+        }
     }
 }

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -33,7 +33,6 @@ public class BudgetResponse {
         private Integer percent;
     }
 
-
     @Builder
     @Getter
     @NoArgsConstructor
@@ -50,7 +49,7 @@ public class BudgetResponse {
                 "      \"amount\": 100000\n" +
                 "    }\n" +
                 "  ]")
-        private List<BudgetRequest.BudgetCreateDTO.DefaultCategoryBudget> defaultCategoryBudgets;
+        private List<BudgetResponse.BudgetDetailDTO.DefaultCategoryBudget> defaultCategoryBudgets;
 
         @Schema(description = "내 카테고리별 예산 목록", example = "  \"customCategoryBudgets\": [\n" +
                 "    {\n" +
@@ -58,7 +57,7 @@ public class BudgetResponse {
                 "      \"amount\": 150000\n" +
                 "    }\n" +
                 "  ],")
-        private List<BudgetRequest.BudgetCreateDTO.CustomCategoryBudget> customCategoryBudgets;
+        private List<BudgetResponse.BudgetDetailDTO.CustomCategoryBudget> customCategoryBudgets;
 
         @Schema(description = "소비 루틴 카테고리 예산 목록", example = "  \"routineCategoryBudgets\": [\n" +
                 "    {\n" +
@@ -66,7 +65,7 @@ public class BudgetResponse {
                 "      \"amount\": 100000\n" +
                 "    }\n" +
                 "  ]")
-        private List<BudgetRequest.BudgetCreateDTO.RoutineCategoryBudget> routineCategoryBudgets;
+        private List<BudgetResponse.BudgetDetailDTO.RoutineCategoryBudget> routineCategoryBudgets;
 
         @Builder
         @Getter

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -23,6 +23,9 @@ public class BudgetResponse {
     @AllArgsConstructor
     @Schema(description = "한 달 총 소비 사용 금액 응답 정보")
     public static class TotalConsumptionResultDTO {
+        @Schema(description = "예산 아이디", example = "1")
+        private Long budgetId;
+
         @Schema(description = "한 달 총 소비 금액", example = "78000")
         private Integer totalConsumption;
 

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -1,14 +1,33 @@
 package com.server.money_touch.domain.budget.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class BudgetResponse {
 
+    @Builder
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "한 달 예산 등록 응답 정보")
     public static class BudgetCreateResultDTO {
         @Schema(description = "예산 아이디", example = "1")
-        private Long budgetId = 1L;
+        private Long budgetId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "한 달 총 소비 사용 금액 응답 정보")
+    public static class TotalConsumptionResultDTO {
+        @Schema(description = "한 달 총 소비 금액", example = "78000")
+        private Integer totalConsumption;
+
+        @Schema(description = "한 달 예산 대비 총 소비 금액 퍼센트", example = "50")
+        private Integer percent;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/fixed-consumption")
+@RequestMapping("/api/fixed-consumptions")
 public class FixedConsumptionController {
 
     @Operation(

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -1,0 +1,86 @@
+package com.server.money_touch.domain.fixedConsumption.controller;
+
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "가계부 고정비 페이지", description = "가계부 고정비에 관한 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/fixed-consumption")
+public class FixedConsumptionController {
+
+    @Operation(
+            summary = "고정비 등록 API",
+            description = "고정비 등록 API 입니다. 금액, 카테고리, 항목명, 메모를 RequestBody로 입력받아 고정비를 등록합니다."
+    )
+    @ApiSuccessCodeExample(resultClass = FixedConsumptionRequest.FixedConsumptionCreateDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @PostMapping()
+    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCreateResultDTO> postFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request) {
+        FixedConsumptionResponse.FixedConsumptionCreateResultDTO response = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    @Operation(
+            summary = "고정비 수정 API",
+            description = "고정비 ID를 통해 등록된 항목을 찾아, 금액·카테고리·항목명·메모를 수정하는 API입니다. " +
+                    "ID는 Path 파라미터로, 수정 정보는 RequestBody로 입력받습니다."
+    )
+    @ApiSuccessCodeExample(resultClass = FixedConsumptionRequest.FixedConsumptionCreateDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "FIXED_CONSUMPTION_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "fixedConsumptionId", description = "수정하려는 고정비 아이디", example = "1", required = true),
+    })
+    @PatchMapping("/{fixedConsumptionId}")
+    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCreateResultDTO> postFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request,
+                                               @PathVariable Long fixedConsumptionId) {
+        FixedConsumptionResponse.FixedConsumptionCreateResultDTO response = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    @Operation(
+            summary = "고정비 삭제 API",
+            description = "고정비 ID를 통해 등록된 항목을 찾아, 고정비를 삭제하는 API 입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = ApiResponse.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "FIXED_CONSUMPTION_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "fixedConsumptionId", description = "삭제하려는 고정비 아이디", example = "1", required = true),
+    })
+    @DeleteMapping("/{fixedConsumptionId}")
+    public ApiResponse<?> postFixedConsumption(@PathVariable Long fixedConsumptionId) {
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -29,7 +29,7 @@ public class FixedConsumptionController {
             summary = "고정비 등록 API",
             description = "고정비 등록 API 입니다. 금액, 카테고리, 항목명, 메모를 RequestBody로 입력받아 고정비를 등록합니다."
     )
-    @ApiSuccessCodeExample(resultClass = FixedConsumptionRequest.FixedConsumptionCreateDTO.class)
+    @ApiSuccessCodeExample(resultClass = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
@@ -47,7 +47,7 @@ public class FixedConsumptionController {
             description = "고정비 ID를 통해 등록된 항목을 찾아, 금액·카테고리·항목명·메모를 수정하는 API입니다. " +
                     "ID는 Path 파라미터로, 수정 정보는 RequestBody로 입력받습니다."
     )
-    @ApiSuccessCodeExample(resultClass = FixedConsumptionRequest.FixedConsumptionCreateDTO.class)
+    @ApiSuccessCodeExample(resultClass = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "FIXED_CONSUMPTION_NOT_FOUND"),

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionRequest.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionRequest.java
@@ -1,0 +1,36 @@
+package com.server.money_touch.domain.fixedConsumption.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class FixedConsumptionRequest {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "고정비 등록 요청 정보")
+    public static class FixedConsumptionCreateDTO{
+
+        @Schema(description = "고정비 금액", example = "20000")
+        @NotNull(message = "고정비 금액은 필수입니다.")
+        private Integer amount;
+
+        @Schema(description = "소비 카테고리 이름", example = "배달/외식")
+        @NotNull(message = "소비 카테고리 이름은 필수입니다.")
+        private String categoryName;
+
+        @Schema(description = "항목명", example = "구독 요금")
+        @NotNull(message = "항목명 이름은 필수입니다.")
+        @Size(max = 20, message = "항목명은 20자 이하로 입력해주세요.")
+        private String content;
+
+        @Schema(description = "메모", example = "가족 공유 요금제")
+        @NotNull(message = "메모는 필수입니다.")
+        @Size(max = 1000, message = "항목명은 1000자 이하로 입력해주세요.")
+        private String memo;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionResponse.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionResponse.java
@@ -1,0 +1,20 @@
+package com.server.money_touch.domain.fixedConsumption.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FixedConsumptionResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "고정비 등록 응답 정보")
+    public static class FixedConsumptionCreateResultDTO {
+        @Schema(description = "고정비 아이디", example = "1")
+        private Long fixedConsumptionId;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -51,7 +51,7 @@ public class RoutineController {
 
     // 내 소비 루틴 목록 조회
     @Operation(
-            summary = "사용자가 등록한 소비 루틴 목록 조회 API",
+            summary = "내 소비 루틴 목록 조회 API",
             description = "가계부에서 사용자가 등록한 소비 루틴 목록을 조회하는 API입니다."
     )
 //    @ApiSuccessCodeExample(resultClass = RoutineResponse.MyRoutineListDTO.class)

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -1,0 +1,52 @@
+package com.server.money_touch.domain.routine.controller;
+
+import com.server.money_touch.domain.budget.dto.BudgetResponse;
+import com.server.money_touch.domain.routine.dto.RoutineRequest;
+import com.server.money_touch.domain.routine.dto.RoutineResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "가계부 소비 루틴 페이지", description = "가계부 소비 루틴에 관한 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/routines")
+public class RoutineController {
+
+    // 소비 루틴 등록
+    @Operation(
+            summary = "소비 루틴 등록 API",
+            description = "소비 루틴을 등록하는 API입니다. 예산 아이디는 Path Variable로 전달하며, 카테고리, 금액, 설명 등의 소비 루틴 정보는 RequestBody에 포함해 주세요."
+    )
+    @ApiSuccessCodeExample(resultClass = RoutineResponse.RoutineCreateResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "budgetId", description = "한 달 예산 아이디", example = "1", required = true),
+    })
+    @PostMapping("/{budgetId}")
+    public ApiResponse<RoutineResponse.RoutineCreateResultDTO> postRoutine(@Valid @RequestBody RoutineRequest.RoutineCreateDTO request,
+                                                                    @PathVariable Long budgetId) {
+        RoutineResponse.RoutineCreateResultDTO response = RoutineResponse.RoutineCreateResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -1,6 +1,5 @@
 package com.server.money_touch.domain.routine.controller;
 
-import com.server.money_touch.domain.budget.dto.BudgetResponse;
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.global.apiPayload.ApiResponse;
@@ -47,6 +46,23 @@ public class RoutineController {
     public ApiResponse<RoutineResponse.RoutineCreateResultDTO> postRoutine(@Valid @RequestBody RoutineRequest.RoutineCreateDTO request,
                                                                     @PathVariable Long budgetId) {
         RoutineResponse.RoutineCreateResultDTO response = RoutineResponse.RoutineCreateResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+    //내 소비 루틴 목록 조회
+    @Operation(
+            summary = "사용자가 등록한 소비 루틴 조회 API",
+            description = "가계부에서 사용자가 등록한 소비 루틴 목록을 조회하는 API입니다."
+    )
+//    @ApiSuccessCodeExample(resultClass = RoutineResponse.MyRoutineListDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @GetMapping("/users")
+    public ApiResponse<RoutineResponse.MyRoutineListDTO> getMyRoutines() {
+        RoutineResponse.MyRoutineListDTO response = RoutineResponse.MyRoutineListDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -49,9 +49,9 @@ public class RoutineController {
         return ApiResponse.onSuccess(response);
     }
 
-    //내 소비 루틴 목록 조회
+    // 내 소비 루틴 목록 조회
     @Operation(
-            summary = "사용자가 등록한 소비 루틴 조회 API",
+            summary = "사용자가 등록한 소비 루틴 목록 조회 API",
             description = "가계부에서 사용자가 등록한 소비 루틴 목록을 조회하는 API입니다."
     )
 //    @ApiSuccessCodeExample(resultClass = RoutineResponse.MyRoutineListDTO.class)

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
@@ -32,11 +32,8 @@ public class RoutineRequest {
         @Size(max = 1000, message = "소비 루틴 소개는 1000자 이하로 입력해주세요.")
         private String routineDescription;
 
-        @Schema(
-                description = "소비 루틴 해시태그 목록",
-                example = "[{\"hashtagName\": \"#식비절약\"}, {\"hashtagName\": \"#생활비\"}]"
-        )
-        private List<RoutineRequest.RoutineHashtagDTO> hashtags;
+        @Schema(description = "소비 루틴 해시태그 목록", example = "[\"#식비절약\", \"#생활비\"]")
+        private List<String> hashtags;
 
         @Schema(description = "카테고리별 예산 목록")
         @NotNull(message = "카테고리별 예산 목록은 비어 있을 수 없습니다.")
@@ -58,14 +55,5 @@ public class RoutineRequest {
             @NotNull(message = "카테고리 금액은 필수입니다.")
             private Integer amount;
         }
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @Schema(description = "소비 루틴 등록 해시태그 정보")
-    public static class RoutineHashtagDTO {
-        @Schema(description = "해시태그 이름", example = "#식비절약")
-        private String hashtagName;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
@@ -1,0 +1,71 @@
+package com.server.money_touch.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class RoutineRequest {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "소비 루틴 등록 요청 정보")
+    public static class RoutineCreateDTO {
+
+        @Schema(description = "한 달 전체 예산", example = "500000")
+        @NotNull(message = "전체 예산은 필수 입력 항목입니다.")
+        private Integer totalBudget;
+
+        @Schema(description = "소비 루틴 이름", example = "50만원으로 한 달 살기 루틴")
+        @NotNull(message = "소비 루틴 이름은 필수입니다.")
+        @Size(max = 20, message = "소비 루틴 이름은 20자 이하로 입력해주세요.")
+        private String routineName;
+
+        @Schema(description = "소비 루틴 소개", example = "적당히 놀고 쓸만큼 써도 50만원이면 해결할 수 있어요!")
+        @NotNull(message = "소비 루틴 소개는 필수입니다.")
+        @Size(max = 1000, message = "소비 루틴 소개는 1000자 이하로 입력해주세요.")
+        private String routineDescription;
+
+        @Schema(
+                description = "소비 루틴 해시태그 목록",
+                example = "[{\"hashtagName\": \"#식비절약\"}, {\"hashtagName\": \"#생활비\"}]"
+        )
+        private List<RoutineRequest.RoutineHashtagDTO> hashtags;
+
+        @Schema(description = "카테고리별 예산 목록")
+        @NotNull(message = "카테고리별 예산 목록은 비어 있을 수 없습니다.")
+        @Valid
+        private List<RoutineRequest.RoutineCreateDTO.CategoryBudget> categoryBudgets;
+
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @Schema(description = "카테고리별 예산")
+        public static class CategoryBudget {
+
+            @Schema(description = "예산 카테고리명", example = "배달/외식")
+            @NotNull(message = "카테고리 이름은 필수입니다.")
+            @Size(max = 8, message = "카테고리 이름은 8자 이하로 입력해주세요.")
+            private String categoryName;
+
+            @Schema(description = "카테고리별 예산 금액", example = "100000")
+            @NotNull(message = "카테고리 금액은 필수입니다.")
+            private Integer amount;
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "소비 루틴 등록 해시태그 정보")
+    public static class RoutineHashtagDTO {
+        @Schema(description = "해시태그 이름", example = "#식비절약")
+        private String hashtagName;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -1,0 +1,20 @@
+package com.server.money_touch.domain.routine.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RoutineResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "소비 루틴 등록 응답 정보")
+    public static class RoutineCreateResultDTO {
+        @Schema(description = "소비 루틴 아이디", example = "1")
+        private Long routineId;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -1,10 +1,12 @@
 package com.server.money_touch.domain.routine.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class RoutineResponse {
 
@@ -16,5 +18,52 @@ public class RoutineResponse {
     public static class RoutineCreateResultDTO {
         @Schema(description = "소비 루틴 아이디", example = "1")
         private Long routineId;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "가계부 내가 등록한 소비 루틴 정보")
+    public static class MyRoutineListDTO {
+        @Schema(description = "내가 등록한 소비 루틴 목록")
+        List<MyRoutineDetailDTO> routineList;
+
+        @Schema(description = "현재 페이지의 소비 루틴 개수", example = "20")
+        Integer routineListSize;
+
+        @Schema(description = "페이지 처음 여부", example = "true")
+        Boolean isFirst;
+
+        @Schema(description = "페이지 마지막 여부", example = "false")
+        Boolean isLast;
+
+        @Schema(description = "다음 페이지가 있는지 여부", example = "true")
+        Boolean hasNext;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "내가 등록한 소비 루틴 세부 정보, 소비 루틴 조회시 List로 전달")
+    public static class MyRoutineDetailDTO {
+
+        @Schema(description = "소비 루틴 등록 날짜", example = "2025-07-05T13:45:30\n")
+        private LocalDateTime createDate;
+
+        @Schema(description = "소비 루틴 이름", example = "50만원으로 한 달 살기 루틴")
+        private String routineName;
+
+        @Schema(description = "닉네임", example = "라인")
+        String nickname;
+
+        @Schema(description = "프로필 이미지 url", example = "https://")
+        String profileImgUrl;
+
+        @Schema(description = "소비 루틴 해시태그 목록", example = "[\"#식비절약\", \"#생활비\"]")
+        private List<String> hashtags;
     }
 }

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BUDGET_NOT_FOUND(HttpStatus.BAD_REQUEST, "BUDGET4001", "아이디와 일치하는 예산이 없습니다."),
     TOTAL_BUDGET_EXCEEDED(HttpStatus.BAD_REQUEST, "BUDGET4002", "카테고리 예산 총합이 전체 예산을 초과합니다."),
     TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다."),
+    BUDGET_NOT_EXIST(HttpStatus.NOT_FOUND, "BUDGET_4041", "이번달에 등록된 예산이 없습니다."),
 
     // 고정비 관련 에러
     FIXED_CONSUMPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FIXED_CONSUMPTION4001", "아이디와 일치하는 고정비가 없습니다.");

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -20,9 +20,12 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "아이디와 일치하는 사용자가 없습니다."),
 
     // 예산 관련 에러
-    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "BUDGET4001", "아이디와 일치하는 예산 정보를 찾을 수 없습니다."),
+    BUDGET_NOT_FOUND(HttpStatus.BAD_REQUEST, "BUDGET4001", "아이디와 일치하는 예산이 없습니다."),
     TOTAL_BUDGET_EXCEEDED(HttpStatus.BAD_REQUEST, "BUDGET4002", "카테고리 예산 총합이 전체 예산을 초과합니다."),
-    TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다.");
+    TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다."),
+
+    // 고정비 관련 에러
+    FIXED_CONSUMPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FIXED_CONSUMPTION4001", "아이디와 일치하는 고정비가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/server/money_touch/global/config/SwaggerConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SwaggerConfig.java
@@ -24,6 +24,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -152,24 +155,59 @@ public class SwaggerConfig {
         mediaType.addExamples("COMMON200", new Example().value(resultJson));
     }
 
-    private Object generateDtoFromSchemaExample(Class<?> dtoClass) {
-        try {
-            Object instance = dtoClass.getDeclaredConstructor().newInstance();
-            for (Field field : dtoClass.getDeclaredFields()) {
-                field.setAccessible(true);
-                Schema schema = field.getAnnotation(Schema.class);
-                if (schema != null && !schema.example().isEmpty()) {
-                    Object exampleValue = convertToFieldType(schema.example(), field.getType());
-                    if (exampleValue != null) {
-                        field.set(instance, exampleValue);
-                    }
+    private Object generateDtoFromSchemaExample(Class<?> dtoClass) throws Exception {
+        Object instance = dtoClass.getDeclaredConstructor().newInstance();
+        for (Field field : dtoClass.getDeclaredFields()) {
+            field.setAccessible(true);
+
+            Schema schema = field.getAnnotation(Schema.class);
+            if (schema == null) continue;
+
+            String exampleValue = schema.example();
+            Class<?> fieldType = field.getType();
+
+            if (exampleValue.isEmpty()) continue;
+
+            if (fieldType == String.class) {
+                field.set(instance, exampleValue);
+            } else if (fieldType == Integer.class || fieldType == int.class) {
+                field.set(instance, Integer.parseInt(exampleValue));
+            } else if (fieldType == Long.class || fieldType == long.class) {
+                field.set(instance, Long.parseLong(exampleValue));
+            } else if (List.class.isAssignableFrom(fieldType)) {
+                // 리스트 타입 처리
+                Type genericType = ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+                if (genericType instanceof Class<?> genericClass) {
+                    Object childDto = generateDtoFromSchemaExample(genericClass);
+                    field.set(instance, List.of(childDto));
                 }
+            } else {
+                // nested DTO 객체라면 재귀적으로 생성
+                Object nestedObject = generateDtoFromSchemaExample(fieldType);
+                field.set(instance, nestedObject);
             }
-            return instance;
-        } catch (Exception e) {
-            return null;
         }
+        return instance;
     }
+
+//    private Object generateDtoFromSchemaExample(Class<?> dtoClass) {
+//        try {
+//            Object instance = dtoClass.getDeclaredConstructor().newInstance();
+//            for (Field field : dtoClass.getDeclaredFields()) {
+//                field.setAccessible(true);
+//                Schema schema = field.getAnnotation(Schema.class);
+//                if (schema != null && !schema.example().isEmpty()) {
+//                    Object exampleValue = convertToFieldType(schema.example(), field.getType());
+//                    if (exampleValue != null) {
+//                        field.set(instance, exampleValue);
+//                    }
+//                }
+//            }
+//            return instance;
+//        } catch (Exception e) {
+//            return null;
+//        }
+//    }
 
     private Object convertToFieldType(String example, Class<?> type) {
         try {

--- a/src/main/java/com/server/money_touch/global/config/SwaggerConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import com.server.money_touch.global.apiPayload.code.status.SuccessStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -21,6 +22,8 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.lang.reflect.Field;
 
 @Configuration
 public class SwaggerConfig {
@@ -53,7 +56,6 @@ public class SwaggerConfig {
     @Bean
     public OperationCustomizer customize() {
         return (operation, handlerMethod) -> {
-            // 여러 에러 예시 처리
             ApiErrorCodeExamples errorAnnotations = handlerMethod.getMethodAnnotation(ApiErrorCodeExamples.class);
             if (errorAnnotations != null) {
                 for (ApiErrorCodeExample e : errorAnnotations.value()) {
@@ -66,7 +68,6 @@ public class SwaggerConfig {
                 }
             }
 
-            // 성공 예시 처리
             ApiSuccessCodeExample successAnnotation = handlerMethod.getMethodAnnotation(ApiSuccessCodeExample.class);
             if (successAnnotation != null) {
                 generateSuccessCodeResponseExample(operation, successAnnotation.resultClass());
@@ -110,37 +111,36 @@ public class SwaggerConfig {
     }
 
     private void generateSuccessCodeResponseExample(Operation operation, Class<?> resultClass) {
-        ReasonDTO reason = SuccessStatus._OK.getReasonHttpStatus(); // 공통 메시지 사용
+        ReasonDTO reason = SuccessStatus._OK.getReasonHttpStatus();
         String httpStatusCode = String.valueOf(reason.getHttpStatus().value());
 
         String resultJson;
         try {
-            Object dtoInstance = resultClass.getDeclaredConstructor().newInstance();
+            Object dtoInstance = generateDtoFromSchemaExample(resultClass); // ← 수정된 부분
             String dtoJson = objectMapper.writeValueAsString(dtoInstance);
 
             resultJson = String.format("""
-        {
-          "isSuccess": true,
-          "code": "%s",
-          "message": "%s",
-          "result": %s
-        }
-        """, reason.getCode(), reason.getMessage(), dtoJson);
+            {
+              "isSuccess": true,
+              "code": "%s",
+              "message": "%s",
+              "result": %s
+            }
+            """, reason.getCode(), reason.getMessage(), dtoJson);
 
         } catch (Exception e) {
             resultJson = String.format("""
-        {
-          "isSuccess": true,
-          "code": "%s",
-          "message": "%s",
-          "result": {}
-        }
-        """, reason.getCode(), reason.getMessage());
+            {
+              "isSuccess": true,
+              "code": "%s",
+              "message": "%s",
+              "result": {}
+            }
+            """, reason.getCode(), reason.getMessage());
         }
 
         Content content = new Content();
         MediaType mediaType = new MediaType();
-        mediaType.addExamples("Success", new Example().value(resultJson));
         content.addMediaType("application/json", mediaType);
 
         io.swagger.v3.oas.models.responses.ApiResponse apiResponse =
@@ -149,7 +149,35 @@ public class SwaggerConfig {
                         .content(content);
 
         operation.getResponses().put(httpStatusCode, apiResponse);
-
         mediaType.addExamples("COMMON200", new Example().value(resultJson));
+    }
+
+    private Object generateDtoFromSchemaExample(Class<?> dtoClass) {
+        try {
+            Object instance = dtoClass.getDeclaredConstructor().newInstance();
+            for (Field field : dtoClass.getDeclaredFields()) {
+                field.setAccessible(true);
+                Schema schema = field.getAnnotation(Schema.class);
+                if (schema != null && !schema.example().isEmpty()) {
+                    Object exampleValue = convertToFieldType(schema.example(), field.getType());
+                    if (exampleValue != null) {
+                        field.set(instance, exampleValue);
+                    }
+                }
+            }
+            return instance;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Object convertToFieldType(String example, Class<?> type) {
+        try {
+            if (type == String.class) return example;
+            if (type == Integer.class || type == int.class) return Integer.parseInt(example);
+            if (type == Long.class || type == long.class) return Long.parseLong(example);
+            if (type == Boolean.class || type == boolean.class) return Boolean.parseBoolean(example);
+        } catch (Exception ignored) {}
+        return null;
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #21 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 고정비 등록&삭제&수정 API 명세서 작성
- 한 달 예산 등록&조회&수정 API 명세서 작성
- 한 달 총 소비 금액 조회 API 명세서 작성
- 소비 루틴 등록 API 명세서 작성
- 내 소비 루틴 목록 조회 API 명세서 작성 (이 부분은 피그마로 봤을 때는 무한스크롤에 가까워 보이는데, PM 님께 질문한 사항 답변오면 수정하도록 하겠습니다)

나머지 가계부 관련 API(일일 소비 기록 등록, 한 달 소비 내역 조회 등..)는 새로운 이슈 파서 작업하겠습니다.

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
<img width="611" alt="스크린샷 2025-07-09 오전 11 49 00" src="https://github.com/user-attachments/assets/25373843-8cb6-4d6b-a80c-8934ecd36af8" />
<img width="497" alt="스크린샷 2025-07-09 오전 11 52 27" src="https://github.com/user-attachments/assets/b9a7d760-4afa-413b-ba62-583a680bcee8" />

&nbsp;
성공 응답 스웨거 어노테이션 `@ApiSuccessCodeExample(resultClass = .class)` 를 급하게 만들어서 가끔씩 복잡한 dto를 반환할때는 스웨거에 예시 응답에서 result가 `{}` 빈 배열로 보이더라고요. 이런 경우에는 `@ApiSuccessCodeExample(resultClass = .class)` 를 제거하시면 두 번째 사진처럼 반환됩니다!

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1095" alt="스크린샷 2025-07-09 오전 11 46 53" src="https://github.com/user-attachments/assets/fb1649f2-12e6-4a45-a599-415e63596244" />
<img width="1094" alt="스크린샷 2025-07-09 오전 11 47 53" src="https://github.com/user-attachments/assets/2bb3755b-8ad6-4675-9e9c-8f762205e413" />


## 💬 리뷰 요구사항 (선택)
> API 경로가 매끄러운지 궁금합니다. 
