### PR TITLE
[#31] Feat: 홈&소비루틴 관련 API 명세서 작성

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "소비 기록 등록 페이지", description = "소비 기록 등록에 관한 API")
+@Tag(name = "소비 기록 페이지", description = "소비 기록에 관한 API")
 @Slf4j
 @Validated
 @RequiredArgsConstructor

--- a/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
+++ b/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
@@ -1,0 +1,168 @@
+package com.server.money_touch.domain.home.controller;
+
+import com.server.money_touch.domain.home.dto.HomeResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "홈 페이지", description = "홈 화면에 있는 기능 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/home")
+public class HomeController {
+
+    @Operation(
+            summary = "소비 통계 조회",
+            description = "이번 달 상위 5개 소비 카테고리 + 기타 여부 + 최다 소비 항목 반환. " +
+                    "Try it out -> Execute 로 리스트 확인 가능합니다. " +
+                    "임시 더미데이터 입력한 상태")
+    // @ApiSuccessCodeExample(resultClass = HomeResponse.ConsumptionStatisticsTopResponseDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+
+    @GetMapping("/statistics")
+    public ApiResponse<HomeResponse.ConsumptionStatisticsTopResponseDTO> getTopStatistics(){
+
+        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
+        List<HomeResponse.ConsumptionStatisticsDTO> top5 = List.of(
+                new HomeResponse.ConsumptionStatisticsDTO("배달/외식", 35.0),
+                new HomeResponse.ConsumptionStatisticsDTO("카페", 25.0),
+                new HomeResponse.ConsumptionStatisticsDTO("고정비", 13.0),
+                new HomeResponse.ConsumptionStatisticsDTO("패션/쇼핑", 10.0),
+                new HomeResponse.ConsumptionStatisticsDTO("교통", 10.0)
+
+        );
+
+        boolean hasOthers = true;
+        String mostSpentCategoryName = "배달/외식";
+
+        return ApiResponse.onSuccess(
+                new HomeResponse.ConsumptionStatisticsTopResponseDTO(top5, hasOthers, mostSpentCategoryName)
+        );
+
+    }
+
+    @Operation(
+            summary = "기타 카테고리 통계 조회",
+            description = "'그 외'를 클릭했을 때 상위 5개를 제외한 카테고리들의 소비 퍼센트 반환. " +
+                    "Try it out -> Execute 로 리스트 확인 가능합니다. " +
+                    "임시 더미데이터 입력한 상태")
+    //@ApiSuccessCodeExample(resultClass = HomeResponse.OtherCategoryStatisticsResponseDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @GetMapping("/statistics/others")
+    public ApiResponse<HomeResponse.OtherCategoryStatisticsResponseDTO> getOtherStatistics(){
+
+
+        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
+        List<HomeResponse.ConsumptionStatisticsDTO> others = List.of(
+                new HomeResponse.ConsumptionStatisticsDTO("술/유흥", 2.0),
+                new HomeResponse.ConsumptionStatisticsDTO("교육비", 2.0),
+                new HomeResponse.ConsumptionStatisticsDTO("통신비", 2.0),
+                new HomeResponse.ConsumptionStatisticsDTO("여행", 1.0)
+        );
+
+        return ApiResponse.onSuccess(new HomeResponse.OtherCategoryStatisticsResponseDTO(others));
+
+    }
+
+    @Operation(
+            summary = "소비왕 랭킹 조회",
+            description = "이번 주 기준 현명해요 수가 가장 많은 유저 10명 + 내 순위를 반환합니다."+
+                    "Try it out -> Execute 로 리스트 확인 가능합니다. " +
+                    "임시 더미데이터 입력한 상태")
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @GetMapping("/ranking")
+    public ApiResponse<HomeResponse.WiseRankingResponseDTO> getWiseRanking() {
+
+        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
+        List<HomeResponse.RankingUserDTO> top10 = List.of(
+                new HomeResponse.RankingUserDTO("제이", "https://", 100, "SAME"),
+                new HomeResponse.RankingUserDTO("영이", "https://", 92, "UP"),
+                new HomeResponse.RankingUserDTO("앨빈", "https://", 87, "DOWN"),
+                new HomeResponse.RankingUserDTO("재현", "https://", 80, "UP"),
+                new HomeResponse.RankingUserDTO("도영", "https://", 75, "DOWN"),
+                new HomeResponse.RankingUserDTO("마크", "https://", 70, "SAME"),
+                new HomeResponse.RankingUserDTO("해찬", "https://", 60, "SAME"),
+                new HomeResponse.RankingUserDTO("유타", "https://", 55, "UP"),
+                new HomeResponse.RankingUserDTO("태용", "https://", 40, "DOWN"),
+                new HomeResponse.RankingUserDTO("정우", "https://", 35, "SAME")
+        );
+
+        HomeResponse.MyRankingDTO myRank = new HomeResponse.MyRankingDTO(
+                "라인", "https://", 89, 11
+        );
+
+        return ApiResponse.onSuccess(new HomeResponse.WiseRankingResponseDTO(top10, myRank));
+    }
+
+    @Operation(
+            summary = "소비 루틴 목록 5개 조회",
+            description = "사용자들이 등록한 소비 루틴들을 조회순 5개 보여줍니다.당일 등록된 루틴은 NEW 표시가 추가됩니다."+
+            "Try it out -> Execute 로 리스트 확인 가능합니다. " +
+            "임시 더미데이터 입력한 상태")
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
+    })
+    @GetMapping("/routinesPreview")
+    public ApiResponse<List<HomeResponse.RoutinePreviewDTO>> getRoutinePreviews() {
+
+        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
+        List<HomeResponse.RoutinePreviewDTO> routines = List.of(
+                new HomeResponse.RoutinePreviewDTO(
+                        1L, "https://",
+                        "50만원으로 한 달 살기 루틴",
+                        true
+                ),
+                new HomeResponse.RoutinePreviewDTO(
+                        2L,"https://",
+                        "배달 끊고 집밥 먹기 예산",
+                         true
+                ),
+                new HomeResponse.RoutinePreviewDTO(
+                        3L, "https://",
+                        "커피값을 아끼자",
+                        false
+                ),
+                new HomeResponse.RoutinePreviewDTO(
+                        4L, "https://",
+                        "쇼핑은 10만원만",
+                        false
+                ),
+                new HomeResponse.RoutinePreviewDTO(
+                        5L, "https://",
+                        "줄줄 새는 고정비 확인하기",
+                        false
+                )
+        );
+
+        return ApiResponse.onSuccess(routines);
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/home/dto/HomeResponse.java
+++ b/src/main/java/com/server/money_touch/domain/home/dto/HomeResponse.java
@@ -1,0 +1,113 @@
+package com.server.money_touch.domain.home.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public class HomeResponse {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Schema(description = "소비 통계 응답 정보")
+    public static class ConsumptionStatisticsDTO {
+
+        @Schema(description = "카테고리 이름", example = "배달/외식")
+        private String categoryName;
+
+        @Schema(description = "소비 비율(소수점 1자리까지. 합계 100%)", example = "35")
+        private double percentage;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "소비 통계 Top5 카테고리 + 기타")
+    public static class ConsumptionStatisticsTopResponseDTO {
+
+        @Schema(description = "상위 5개 소비 카테고리")
+        private List<ConsumptionStatisticsDTO> topCategories;
+
+        @Schema(description = "그 외 카테고리 존재 여부", example = "true")
+        private boolean hasOthers;
+
+        @Schema(description = "이번 달 최다 소비 항목", example = "배달/외식")
+        private String mostSpentCategoryName;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "기타 카테고리 상세")
+    public static class OtherCategoryStatisticsResponseDTO {
+        private List<ConsumptionStatisticsDTO> otherCategories;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "소비왕 랭킹 응답 DTO")
+    public static class WiseRankingResponseDTO {
+
+        @Schema(description = "상위 10명의 유저 정보")
+        private List<RankingUserDTO> top10Users;
+
+        @Schema(description = "본인 순위 정보")
+        private MyRankingDTO myRank;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "소비왕 랭킹 유저 10명")
+    public static class RankingUserDTO {
+
+        @Schema(description = "닉네임", example = "제이")
+        private String nickname;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://")
+        private String profileImgUrl;
+
+        @Schema(description = "현명해요 수", example = "100")
+        private int wiseCount;
+
+        @Schema(description = "등락 상태 (UP, DOWN, SAME)", example = "UP")
+        private String rankChangeStatus;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "본인 순위 정보")
+    public static class MyRankingDTO {
+        @Schema(description = "닉네임", example = "라인")
+        private String nickname;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://")
+        private String profileImgUrl;
+
+        @Schema(description = "랭킹", example = "89")
+        private int ranking;
+
+        @Schema(description = "총 현명해요 수", example = "11")
+        private int totalWiseCount;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "소비 루틴 조회순 5개")
+    public static class RoutinePreviewDTO {
+
+        @Schema(description = "소비 루틴 id", example = "1")
+        private Long routineId;
+
+        @Schema(description = "아이콘 이미지", example = "https://")
+        private String iconImgUrl;
+
+        @Schema(description = "루틴 이름", example = "50만원으로 한 달 살기 루틴")
+        private String routineName;
+
+        @Schema(description = "당일 등록 여부", example = "true")
+        private boolean isNew;
+    }
+
+
+}

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "가계부 소비 루틴 페이지", description = "가계부 소비 루틴에 관한 API")
 @Slf4j
 @Validated
@@ -33,7 +35,6 @@ public class RoutineController {
     @ApiSuccessCodeExample(resultClass = RoutineResponse.RoutineCreateResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_ALREADY_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
@@ -64,9 +65,38 @@ public class RoutineController {
     @GetMapping("/users")
     public ApiResponse<RoutineResponse.MyRoutineListDTO> getMyRoutines() {
         RoutineResponse.MyRoutineListDTO response = RoutineResponse.MyRoutineListDTO.builder().build();
-
         return ApiResponse.onSuccess(response);
     }
 
-    // 소비 루틴 이미지 등록?
+    @Operation(
+            summary = "전체 소비 루틴 리스트 조회",
+            description = "최신순으로 전체 소비 루틴을 조회합니다. 임시 더미데이터 입력한 상태입니다. "
+                    + "Try it out -> Execute 로 리스트 확인 가능합니다."
+                    + "당일 등록은 NEW 표시를 위해 true로 전달합니다.")
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
+    })
+    @GetMapping("/list")
+    public ApiResponse<List<RoutineResponse.RoutineListDTO>> getAllRoutines(){
+
+        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
+        List<RoutineResponse.RoutineListDTO> routines = List.of(
+                new RoutineResponse.RoutineListDTO(
+                        1L, true,"2025-07-09","50만원으로 한 달 살기 루틴",
+                        "라인", "https://","https://",
+                        List.of("#식비절약", "#생활비")
+                ),
+
+                new RoutineResponse.RoutineListDTO(
+                        2L,false,"2025-06-10","커피값을 아끼자",
+                        "오리", "https://","https://",
+                        List.of("#카페지출줄이기","#커피절약")
+                )
+        );
+        return ApiResponse.onSuccess(routines);
+    }
+
 }

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -35,6 +35,7 @@ public class RoutineController {
     @ApiSuccessCodeExample(resultClass = RoutineResponse.RoutineCreateResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_ALREADY_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -1,6 +1,5 @@
 package com.server.money_touch.domain.routine.dto;
 
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -1,8 +1,7 @@
 package com.server.money_touch.domain.routine.dto;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -72,4 +71,37 @@ public class RoutineResponse {
         @Schema(description = "소비 루틴 해시태그 목록", example = "[\"#식비절약\", \"#생활비\"]")
         private List<String> hashtags;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "전체 소비 루틴 리스트")
+    public static class RoutineListDTO {
+
+        @Schema(description = "소비 루틴 아이디", example = "1")
+        private Long routineId;
+
+        @Schema(description = "NEW 여부", example = "true")
+        private boolean isNew;
+
+        @Schema(description = "소비 루틴 등록 날짜", example = "2025-07-09")
+        private String createDate;
+
+        @Schema(description = "소비 루틴 이름", example = "50만원으로 한 달 살기 루틴")
+        private String routineName;
+
+        @Schema(description = "닉네임", example = "라인")
+        private String nickname;
+
+        @Schema(description = "소비 루틴 이미지 url", example = "https://")
+        private String routineImgUrl;
+
+        @Schema(description = "프로필 이미지 url", example = "https://")
+        private String profileImgUrl;
+
+        @Schema(description = "소비 루틴 해시태그 목록", example = "[\"#식비절약\", \"#생활비\"]")
+        private List<String> hashtags;
+
+    }
+
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #31 

## 📝 작업 내용

- 소비 통계, 똑똑 소비왕 랭킹, 전체 소비 루틴 리스트, 소비 루틴 조회순 5개 보여주는 api 작업
- 검색, 타인의 한달 소비 루틴 적용하는 api 는 내일까지 작성할 예정

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
이슈에 포함했습니다!
