### PR TITLE
[#35]Feat: 소비루틴 상세조회 api 명세서 작성

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -121,4 +121,23 @@ public class RoutineController {
 
     // 소비 루틴 이미지 등록
 
+
+    @Operation(
+            summary = "타인의 소비루틴 상세 조회",
+            description = "전체 소비 루틴 리스트에서 소비 루틴 상세 정보를 조회하는 API입니다.")
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "routineId", description = "조회하려는 소비 루틴 아이디", example = "1", required = true),
+    })
+    @GetMapping("/list/{routineId}")
+    public ApiResponse<RoutineResponse.RoutineListDetailDTO> getOtherDetailRoutine(@PathVariable Long routineId) {
+        RoutineResponse.RoutineListDetailDTO response = RoutineResponse.RoutineListDetailDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -148,4 +148,33 @@ public class RoutineResponse {
         @Schema(description = "카테고리별 예산 금액", example = "100000")
         private Integer amount;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "타인 루틴 상세 응답")
+    public static class RoutineListDetailDTO {
+
+        @Schema(description = "한 달 전체 예산", example = "500000")
+        private Integer totalBudget;
+
+        @Schema(description = "소비 루틴 이름", example = "50만원으로 한 달 살기 루틴")
+        private String routineName;
+
+        @Schema(description = "카테고리별 예산 목록", example = """
+        [
+          {
+            "categoryName": "배달/외식",
+            "amount": 100000
+          },
+          {
+            "categoryName": "카페",
+            "amount": 400000
+          }
+        ]
+        """)
+        private List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList;
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #35 

## 📝 작업 내용

<img width="1230" height="187" alt="image" src="https://github.com/user-attachments/assets/0b52e53e-77d0-4208-9d50-9a9db09ea9ac" />
<img width="2091" height="801" alt="image" src="https://github.com/user-attachments/assets/e7513e28-da4d-4b28-82d8-5fbf19c3d197" />

- 소비루틴 상세조회 api 명세서 작성
- 미정님이 올리신 상세조회와 같은 기능이지만, 다른 url 이어야 할 것 같아 url 수정, 메모 삭제만 했습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

