### PR TITLE
[#25] Feat: 피드&마이페이지 관련 API 명세서 작성

### DIFF
--- a/src/main/java/com/server/money_touch/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/server/money_touch/domain/badge/controller/BadgeController.java
@@ -1,0 +1,67 @@
+package com.server.money_touch.domain.badge.controller;
+
+import com.server.money_touch.domain.badge.dto.BadgeResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "배지 페이지", description = "배지에 관한 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/badge")
+public class BadgeController {
+
+    @Operation(
+            summary = "내가 획득한 배지 목록 조회 API",
+            description = "현재 로그인한 사용자가 획득한 배지 목록을 조회하는 API 입니다."
+    )
+//    @ApiSuccessCodeExample(resultClass = BadgeResponse.MyBadgeListResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @GetMapping("/my")
+    public ApiResponse<BadgeResponse.MyBadgeListResultDTO> getMyBadges() {
+        BadgeResponse.MyBadgeListResultDTO response = BadgeResponse.MyBadgeListResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 대표 배지 설정
+    @Operation(
+            summary = "대표 배지 설정 API",
+            description = "획득한 배지 중에서 대표 배지를 설정하는 API입니다. UserBadge 테이블에서 획득 여부를 확인 후 User 엔티티의 badgeId를 업데이트합니다."
+    )
+//    @ApiSuccessCodeExample(resultClass = BadgeResponse.BadgeDetailResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_EARNED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @Parameters({
+            @Parameter(name = "badgeId", description = "설정할 대표 배지 ID", example = "1", required = true)
+    })
+    @PatchMapping("/representative/{badgeId}")
+    public ApiResponse<BadgeResponse.BadgeDetailResultDTO> setRepresentativeBadge(
+//            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long badgeId
+    ) {
+        BadgeResponse.BadgeDetailResultDTO response = BadgeResponse.BadgeDetailResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/server/money_touch/domain/badge/controller/BadgeController.java
@@ -6,13 +6,13 @@ import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "배지 페이지", description = "배지에 관한 API")
 @Slf4j
@@ -36,31 +36,6 @@ public class BadgeController {
     @GetMapping("/my")
     public ApiResponse<BadgeResponse.MyBadgeListResultDTO> getMyBadges() {
         BadgeResponse.MyBadgeListResultDTO response = BadgeResponse.MyBadgeListResultDTO.builder().build();
-        return ApiResponse.onSuccess(response);
-    }
-
-    // 대표 배지 설정
-    @Operation(
-            summary = "대표 배지 설정 API",
-            description = "획득한 배지 중에서 대표 배지를 설정하는 API입니다. UserBadge 테이블에서 획득 여부를 확인 후 User 엔티티의 badgeId를 업데이트합니다."
-    )
-//    @ApiSuccessCodeExample(resultClass = BadgeResponse.BadgeDetailResultDTO.class)
-    @ApiErrorCodeExamples({
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_FOUND"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_EARNED"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
-    })
-    @Parameters({
-            @Parameter(name = "badgeId", description = "설정할 대표 배지 ID", example = "1", required = true)
-    })
-    @PatchMapping("/representative/{badgeId}")
-    public ApiResponse<BadgeResponse.BadgeDetailResultDTO> setRepresentativeBadge(
-//            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @PathVariable Long badgeId
-    ) {
-        BadgeResponse.BadgeDetailResultDTO response = BadgeResponse.BadgeDetailResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/badge/dto/BadgeResponse.java
+++ b/src/main/java/com/server/money_touch/domain/badge/dto/BadgeResponse.java
@@ -1,0 +1,45 @@
+package com.server.money_touch.domain.badge.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class BadgeResponse {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "내가 획득한 배지 목록")
+    public static class MyBadgeListResultDTO {
+
+        @Schema(description = "획득한 배지 리스트")
+        private List<BadgeDetailResultDTO> badges;
+
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "배지 상세 정보")
+    public static class BadgeDetailResultDTO {
+
+        @Schema(description = "배지 ID", example = "1")
+        private Long badgeId;
+
+        @Schema(description = "배지 이름", example = "똑똑소비대장")
+        private String name;
+
+        @Schema(description = "배지 이미지 URL", example = "https://example.com/badge.png")
+        private String imageUrl;
+
+        @Schema(description = "배지 설명", example = "똑똑소비왕 10위권 달성 시")
+        private String description;
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/badge/entity/Badge.java
+++ b/src/main/java/com/server/money_touch/domain/badge/entity/Badge.java
@@ -21,5 +21,7 @@ public class Badge {
     @Column(nullable = false)
     private String imageUrl;
 
+    @Column(nullable = false, length = 100)
+    private String description;
 
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/FeedController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/FeedController.java
@@ -6,7 +6,6 @@ import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
-import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -108,4 +107,29 @@ public class FeedController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 리액션 추가/변경
+    @Operation(
+            summary = "피드 반응 추가/변경/삭제 API",
+            description = "피드에 현명해요 또는 낭비에요 반응을 추가하거나 변경 혹은 삭제하는 API입니다. 이미 반응이 있으면 변경되고, 같은 반응을 누르면 취소됩니다."
+    )
+//    @ApiSuccessCodeExample(resultClass = ReactionResponse.ReactionResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_RECORD_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "REACTION_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @Parameters({
+            @Parameter(name = "consumptionRecordId", description = "소비 기록 ID", example = "1", required = true)
+    })
+    @PostMapping("/{consumptionRecordId}/reaction")
+    public ApiResponse<FeedResponse.ReactionResultDTO> addOrUpdateReaction(
+//            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long consumptionRecordId,
+            @RequestBody @Valid FeedRequest.ReactionCreateDTO request
+    ) {
+        FeedResponse.ReactionResultDTO response = FeedResponse.ReactionResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/FeedController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/FeedController.java
@@ -132,4 +132,28 @@ public class FeedController {
         FeedResponse.ReactionResultDTO response = FeedResponse.ReactionResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
+
+    // 피드 조회수 증가
+    @Operation(
+            summary = "피드 조회수 증가 API",
+            description = "피드를 조회할 때 조회수를 증가시키는 API입니다. 중복 조회는 제한됩니다."
+    )
+//    @ApiSuccessCodeExample(resultClass = FeedResponse.ViewCountResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_RECORD_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @Parameters({
+            @Parameter(name = "consumptionRecordId", description = "소비 기록 ID", example = "1", required = true)
+    })
+    @PatchMapping("/{consumptionRecordId}/view")
+    public ApiResponse<FeedResponse.ViewCountResultDTO> increaseFeedViewCount(
+//            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long consumptionRecordId
+    ) {
+        FeedResponse.ViewCountResultDTO response = FeedResponse.ViewCountResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/FeedRequest.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/FeedRequest.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.consumptionRecord.dto;
 
+import com.server.money_touch.domain.consumptionRecord.enums.ReactionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -25,4 +26,12 @@ public class FeedRequest {
         private String content;
     }
 
+    // 리액션 추가/변경 DTO
+    @Getter
+    @Schema(description = "리액션 추가/변경 요청 DTO")
+    public static class ReactionCreateDTO {
+        @Schema(description = "리액션 타입 (현명해요: WISE / 낭비에요: WASTE)", example = "WISE")
+        @NotNull(message = "리액션 타입은 필수입니다.")
+        private ReactionType type;
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/FeedResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/FeedResponse.java
@@ -124,4 +124,23 @@ public class FeedResponse {
 
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "리액션 결과 DTO")
+    public static class ReactionResultDTO {
+
+        @Schema(description = "소비기록 ID", example = "1")
+        private Long consumptionRecordId;
+
+        @Schema(description = "변경된 현명해요 수", example = "5")
+        private Integer wiseCount;
+
+        @Schema(description = "변경된 낭비에요 수", example = "2")
+        private Integer wasteCount;
+
+        @Schema(description = "현재 내가 누른 리액션 타입 (없으면 null)", example = "WISE")
+        private String myReaction;
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/FeedResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/FeedResponse.java
@@ -143,4 +143,19 @@ public class FeedResponse {
         @Schema(description = "현재 내가 누른 리액션 타입 (없으면 null)", example = "WISE")
         private String myReaction;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "조회수 증가 결과 DTO")
+    public static class ViewCountResultDTO {
+
+        @Schema(description = "소비 기록 ID", example = "1")
+        private Long consumptionRecordId;
+
+        @Schema(description = "증가된 조회수", example = "22")
+        private Integer viewCount;
+
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.server.money_touch.domain.user.controller;
+
+import com.server.money_touch.domain.user.dto.UserResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "유저 페이지", description = "유저에 관한 API")
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    // 마이페이지
+    @Operation(
+            summary = "마이페이지 유저 정보 조회 API",
+            description = "현재 로그인한 사용자의 마이페이지 정보를 조회하는 API입니다."
+    )
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_UNAUTHORIZED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @GetMapping("/mypage")
+    public ApiResponse<UserResponse.MyPageResponseDTO> getMyPage() {
+        UserResponse.MyPageResponseDTO response = UserResponse.MyPageResponseDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -6,12 +6,12 @@ import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "유저 페이지", description = "유저에 관한 API")
 @Validated
@@ -37,4 +37,28 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 대표 배지 설정
+    @Operation(
+            summary = "대표 배지 설정 API",
+            description = "획득한 배지 중에서 대표 배지를 설정하는 API입니다. UserBadge 테이블에서 획득 여부를 확인 후 User 엔티티의 badgeId를 업데이트합니다."
+    )
+//    @ApiSuccessCodeExample(resultClass = BadgeResponse.BadgeDetailResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BADGE_NOT_EARNED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @Parameters({
+            @Parameter(name = "badgeId", description = "설정할 대표 배지 ID", example = "1", required = true)
+    })
+    @PatchMapping("/representative-badge/{badgeId}")
+    public ApiResponse<UserResponse.RepresentativeBadgeResultDTO> setRepresentativeBadge(
+//            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long badgeId
+    ) {
+        UserResponse.RepresentativeBadgeResultDTO response = UserResponse.RepresentativeBadgeResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.user.dto;
 
+import com.server.money_touch.domain.badge.entity.Badge;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +24,7 @@ public class UserResponse {
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
         private String profileImgUrl;
 
-        @Schema(description = "뱃지 ID", example = "1")
-        private Long badgeId;
+        @Schema(description = "대표 뱃지 ID", example = "1")
+        private Badge badgeId;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -27,4 +27,25 @@ public class UserResponse {
         @Schema(description = "대표 뱃지 ID", example = "1")
         private Badge badgeId;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "대표 배지 설정 응답")
+    public static class RepresentativeBadgeResultDTO {
+
+        @Schema(description = "설정된 대표 배지 ID", example = "1")
+        private Long badgeId;
+
+        @Schema(description = "배지 이름", example = "절약왕")
+        private String badgeName;
+
+        @Schema(description = "배지 이미지 URL", example = "https://example.com/badge.png")
+        private String badgeImageUrl;
+
+        @Schema(description = "배지 설명", example = "똑똑소비왕 10위권 달성 시")
+        private String badgeDescription;
+
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -1,0 +1,29 @@
+package com.server.money_touch.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "마이페이지 프로필 정보")
+    public static class MyPageResponseDTO {
+        @Schema(description = "사용자 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "닉네임", example = "라인")
+        private String nickname;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        private String profileImgUrl;
+
+        @Schema(description = "뱃지 ID", example = "1")
+        private Long badgeId;
+    }
+}

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -37,14 +37,17 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 배지 관련 에러
     BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BADGE4001", "존재하지 않는 배지 입니다."),
-    BADGE_NOT_EARNED(HttpStatus.FORBIDDEN, "BADGE4002", "획득하지 않은 배지입니다.");
+    BADGE_NOT_EARNED(HttpStatus.FORBIDDEN, "BADGE4002", "획득하지 않은 배지입니다."),
 
     // 고정비 관련 에러
     FIXED_CONSUMPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FIXED_CONSUMPTION4001", "아이디와 일치하는 고정비가 없습니다."),
 
     // 소비 루틴 관련 에러
     ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE4001", "아이디와 일치하는 소비 루틴이 없습니다."),
-    ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE4002", "한 달 소비 루틴 등록 횟수를 초과하였습니다.");
+    ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE4002", "한 달 소비 루틴 등록 횟수를 초과하였습니다."),
+
+    // 리액션 관련 에러
+    REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REACTION4001", "반응을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -29,11 +29,15 @@ public enum ErrorStatus implements BaseErrorCode {
     CONSUMPTION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "CONSUMPTION4001", "일치하는 소비기록이 존재하지 않습니다."),
 
     // 댓글 관련 에러
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT6001", "존재하지 않는 댓글입니다."),
-    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT6002", "부모 댓글을 찾을 수 없습니다."),
-    NESTED_REPLY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMMENT6003", "대댓글에는 댓글을 달 수 없습니다."),
-    COMMENT_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "COMMENT6004", "댓글 내용이 너무 깁니다. (최대 300자)"),
-    COMMENT_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "COMMENT6005", "댓글 내용을 입력해주세요.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "존재하지 않는 댓글입니다."),
+    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4002", "부모 댓글을 찾을 수 없습니다."),
+    NESTED_REPLY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMMENT4003", "대댓글에는 댓글을 달 수 없습니다."),
+    COMMENT_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "COMMENT4004", "댓글 내용이 너무 깁니다. (최대 300자)"),
+    COMMENT_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "COMMENT4005", "댓글 내용을 입력해주세요."),
+
+    // 배지 관련 에러
+    BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BADGE4001", "존재하지 않는 배지 입니다."),
+    BADGE_NOT_EARNED(HttpStatus.FORBIDDEN, "BADGE4002", "획득하지 않은 배지입니다.");
 
     // 고정비 관련 에러
     FIXED_CONSUMPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FIXED_CONSUMPTION4001", "아이디와 일치하는 고정비가 없습니다."),


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #25 
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 리액션(현명해요/낭비에요) 등록, 수정, 삭제
- 마이페이지 조회
- 내 배지 조회
- 대표 배지 등록, 변경
- 피드 조회수 증가

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  처음에는 대표배지 등록 api를 배지쪽에 두었다가 
   현재 대표배지 등록의 과정이 `user - user badge - badge` 의 구조로 테이블을 설계하여, `대표배지 설정 버튼 누르기 -> userbadge 테이블로 유저가 획득한 배지인지 확인 -> 있다면 user entity의 대표배지 아이디에 등록` 의 과정으로 설계되어 있기 때문에 user 쪽으로 변경하였습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷
<img width="1166" height="398" alt="image" src="https://github.com/user-attachments/assets/e01c28a8-edb2-47d6-be5b-11d4cc96f8a9" />
<img width="2306" height="238" alt="image" src="https://github.com/user-attachments/assets/0e5b3df1-cdb3-48b0-a4d6-6d1537240e0d" />
<img width="1164" height="182" alt="image" src="https://github.com/user-attachments/assets/c52b41d0-da6b-41f9-a426-3e076c8346fb" />
