### PR TITLE
[#39]Feat: 소비루틴 관련 API 명세서 작성

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -140,4 +140,54 @@ public class RoutineController {
         return ApiResponse.onSuccess(response);
     }
 
+    @Operation(
+            summary = "소비 루틴 예산 반영 전 수정/추가",
+            description = "내 예산에 반영-> 네 를 클릭하면 보여주는 api 입니다."+
+                    "사용자가 갖고 있는 기존 카테고리는 '카테고리별 예산', 새로운 카테고리는 '소비 루틴 카테고리' 보여줍니다."
+    )
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "routineId", description = "조회하려는 소비 루틴 아이디", example = "1", required = true),
+    })
+    @GetMapping("/list/{routineId}/apply-info")
+    public ApiResponse<RoutineResponse.ApplyRoutineInfoDTO> getRoutineApplyInfo(@PathVariable Long routineId){
+
+        RoutineResponse.ApplyRoutineInfoDTO response = RoutineResponse.ApplyRoutineInfoDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+
+    }
+
+    @Operation(
+            summary = "소비 루틴 예산 반영",
+            description = "실제 예산에 반영. 새로운 카테고리는 ROUTINE_CATEGORY로 추가"
+    )
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @Parameters({
+            @Parameter(name = "routineId", description = "소비 루틴 ID", required = true, example = "1")
+    })
+    @PutMapping("/list/{routineId}/apply")
+    public ApiResponse<RoutineResponse.ApplyRoutineSuccessDTO> applyRoutineToBudget(
+            @PathVariable Long routineId,
+            @Valid @RequestBody RoutineRequest.ApplyRoutineBudgetDTO request
+    ){
+
+        RoutineResponse.ApplyRoutineSuccessDTO response = RoutineResponse.ApplyRoutineSuccessDTO.builder()
+                .message("예산에 성공적으로 반영되었습니다.")
+                .build();
+
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
@@ -1,12 +1,11 @@
 package com.server.money_touch.domain.routine.dto;
 
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
@@ -58,5 +57,39 @@ public class RoutineRequest {
         @Schema(description = "카테고리별 예산 금액", example = "100000")
         @NotNull(message = "카테고리 금액은 필수입니다.")
         private Integer amount;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "소비 루틴 예산 반영 요청 DTO")
+    public static class ApplyRoutineBudgetDTO {
+
+        @Schema(description = "수정된 전체 예산", example = "500000")
+        private Integer budgetTotal;
+
+        @Schema(description = "반영할 카테고리 예산 목록 (기존+소비루틴 모두 합침)")
+        @NotNull
+        @Valid
+        private List<RoutineRequest.ApplyCategoryBudgetDTO> categoryBudgets;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "카테고리별 예산 정보")
+    public static class ApplyCategoryBudgetDTO {
+
+        @Schema(description = "카테고리명", example = "배달/외식")
+        private String categoryName;
+
+        @Schema(description = "카테고리 금액", example = "100000")
+        private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
+        @NotNull
+        private CategoryType categoryType;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.routine.dto;
 
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -72,7 +73,9 @@ public class RoutineResponse {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
+    @Builder
     @Schema(description = "전체 소비 루틴 리스트")
     public static class RoutineListDTO {
 
@@ -176,5 +179,51 @@ public class RoutineResponse {
         ]
         """)
         private List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "소비 루틴 예산 반영 전 수정/추가 페이지 응답")
+    public static class ApplyRoutineInfoDTO {
+
+        @Schema(description = "총 예산", example = "500000")
+        private Integer totalBudget;
+
+        @Schema(description = "기존 카테고리별 예산 목록")
+        private List<ApplyCategoryBudgetDTO> categoryBudgets;
+
+        @Schema(description = "새로운 소비 루틴 카테고리별 예산 목록")
+        private List<ApplyCategoryBudgetDTO> routineCategoryBudgets;
+
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "카테고리 예산 정보 DTO")
+    public static class ApplyCategoryBudgetDTO {
+
+        @Schema(description = "카테고리명", example = "배달/외식")
+        private String categoryName;
+
+        @Schema(description = "금액", example = "100000")
+        private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
+        private CategoryType categoryType;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "소비 루틴 예산 반영 성공 응답")
+    public static class ApplyRoutineSuccessDTO {
+        @Schema(description = "응답 메시지", example = "예산에 성공적으로 반영되었습니다.")
+        private String message;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #39 

## 📝 작업 내용
<img width="1079" height="162" alt="image" src="https://github.com/user-attachments/assets/1e3bee4d-771d-4db4-b1d6-8da5d9defc91" />
<img width="1241" height="102" alt="image" src="https://github.com/user-attachments/assets/f722ab1c-d832-4eac-88c3-35e0131d175a" />

- 소비 루틴 예산 반영, 반영 전 수정/추가 api 명세서 작성
- 소비 루틴 검색은 월요일까지 완료하겠습니다.


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?
