### PR TITLE
[#26] Feat: 회원관련 API 명세서 작성

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
@@ -8,6 +8,8 @@ import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -24,16 +26,19 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/consumptionMbti")
 public class ConsumptionMbtiController {
 
-    // 소비 Mbti 등록
+    // 소비 Mbti 조회
     @Operation(
             summary = "소비 Mbti 조회 API",
-            description = "소비 Mbti 조회 API 입니다."
+            description = "결과 코드(예: PTG)에 해당하는 소비 MBTI 설명, 부제, 이미지 등을 조회합니다."
     )
     @ApiSuccessCodeExample(resultClass = ConsumptionMbtiResponse.ConsumptionMbtiResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "MBTI_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "result", description = "조회하려는 소비 Mbti", example = "PTG", required = true),
     })
     @GetMapping("/result")
     public ApiResponse<ConsumptionMbtiResponse.ConsumptionMbtiResultDTO> getMbti(@RequestParam @NotBlank(message = "결과값은 필수입니다.") String result) {

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
@@ -8,6 +8,8 @@ import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -24,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/consumptionMbti")
 public class ConsumptionMbtiController {
 
-    // 소비 Mbti 등록
     @Operation(
             summary = "소비 Mbti 조회 API",
             description = "소비 Mbti 조회 API 입니다."
@@ -34,6 +35,9 @@ public class ConsumptionMbtiController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "MBTI_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "result" , description = "조회하려는 소비 MBTI", example = "PTG" , required = true)
     })
     @GetMapping("/result")
     public ApiResponse<ConsumptionMbtiResponse.ConsumptionMbtiResultDTO> getMbti(@RequestParam @NotBlank(message = "결과값은 필수입니다.") String result) {

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
@@ -1,0 +1,44 @@
+package com.server.money_touch.domain.consumptionMbti.controller;
+
+
+import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "소비 Mbti  페이지", description = "소비 Mbti 관한 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/consumptionMbti")
+public class ConsumptionMbtiController {
+
+    // 소비 Mbti 등록
+    @Operation(
+            summary = "소비 Mbti 조회 API",
+            description = "소비 Mbti 조회 API 입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = ConsumptionMbtiResponse.ConsumptionMbtiResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "MBTI_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @GetMapping("/result")
+    public ApiResponse<ConsumptionMbtiResponse.ConsumptionMbtiResultDTO> getMbti(@RequestParam @NotBlank(message = "결과값은 필수입니다.") String result) {
+        ConsumptionMbtiResponse.ConsumptionMbtiResultDTO response = null; //  TODO: 서비스 연결 예정
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/dto/ConsumptionMbtiResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/dto/ConsumptionMbtiResponse.java
@@ -14,5 +14,14 @@ public class ConsumptionMbtiResponse {
 
         @Schema(description = "소비 Mbti 아이디", example = "1")
         private Long mbtiId;
+
+        @Schema(description = "소비 mbti 이름", example = "PTG")
+        private String result;
+
+        @Schema(description = "소비 mbti 설명" ,example = "철저한 계획 아래~")
+        private String description;
+
+        @Schema(description = "소비 mbti 이미지", example = "https://example.com/mbti.jpg")
+        private String mbtiImgUrl;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/dto/ConsumptionMbtiResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/dto/ConsumptionMbtiResponse.java
@@ -1,0 +1,18 @@
+package com.server.money_touch.domain.consumptionMbti.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class ConsumptionMbtiResponse {
+
+    @Builder
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Schema(description = "소비 Mbti 조회 응답 정보")
+    public static class ConsumptionMbtiResultDTO{
+
+        @Schema(description = "소비 Mbti 아이디", example = "1")
+        private Long mbtiId;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -12,6 +12,7 @@ import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -39,7 +40,6 @@ public class ConsumptionRecordController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
-
     @PostMapping("/record")
     public ApiResponse<ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO> postConsumptionRecord(
             @Valid @RequestBody ConsumptionRecordRequest.ConsumptionRecordCreateDTO request){

--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -1,0 +1,75 @@
+package com.server.money_touch.domain.user.controller;
+import com.server.money_touch.domain.user.dto.UserRequest;
+import com.server.money_touch.domain.user.dto.UserResponse;
+import com.server.money_touch.global.apiPayload.ApiResponse;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
+import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
+import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "회원 가입 페이지", description = "회원가입에 관한 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/user")
+public class UserController{
+
+    // 회원 가입
+    @Operation(
+            summary = "로컬 회원가입 API",
+            description = "로컬 로그인 방식의 회원 가입 API 입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = UserResponse.UserCreateResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+
+    @PostMapping("/signup")
+    public ApiResponse<UserResponse.UserCreateResultDTO> signUpLocalUser(
+            @Valid @RequestBody UserRequest.LocalSignUpDTO request){
+
+        UserResponse.UserCreateResultDTO response = UserResponse.UserCreateResultDTO.builder()
+                .userId(1L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return ApiResponse.onSuccess(response);
+    }
+    @Operation(
+            summary = "카카오 회원가입 API",
+            description = "카카오 소셜 로그인 방식의 회원 가입 API 입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = UserResponse.UserCreateResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+
+    @PostMapping("/kakao-signup")
+    public ApiResponse<UserResponse.UserCreateResultDTO> signUpKakaoUser(
+            @Valid @RequestBody UserRequest.KakaoSignUpDto request){
+
+        UserResponse.UserCreateResultDTO response = UserResponse.UserCreateResultDTO.builder()
+                .userId(1L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -7,6 +7,8 @@ import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -121,8 +123,10 @@ public class UserController{
     @PostMapping("/social-login")
     public ApiResponse<UserResponse.LoginResultDTO> socialLogin(
             @Valid @RequestBody UserRequest.SocialLoginRequest request
-    ){
+    ) {
         UserResponse.LoginResultDTO response = UserResponse.LoginResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
 
     // 마이페이지
     @Operation(

--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -12,14 +12,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
-@Tag(name = "회원 가입 페이지", description = "회원가입에 관한 API")
+@Tag(name = "회원 가입 & 로그인 페이지", description = "유저에 관한 API")
 @Slf4j
 @Validated
 @RequiredArgsConstructor
@@ -27,10 +24,30 @@ import java.time.LocalDateTime;
 @RequestMapping("/api/user")
 public class UserController{
 
-    // 회원 가입
+
+    @Operation(
+            summary = "유저 상세정보 저장 API",
+            description = "필수 온보딩 과정에서 유저의 상세정보를 저장하는 API입니다.AccessToken 기반으로 유저를 식별합니다."
+    )
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @PostMapping("/detail")
+    public ApiResponse<UserResponse.UserDetailCreateResultDTO> createUserDetail(
+            //@AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UserRequest.UserDetailCreateDTO request){
+            //Long userId = userPrincipal.getId(); // AccessToken에서 식별된 유저 ID
+        UserResponse.UserDetailCreateResultDTO response = UserResponse.UserDetailCreateResultDTO.builder()
+                .userId(1L)
+                .build();
+        return ApiResponse.onSuccess(response);
+    }
+
     @Operation(
             summary = "로컬 회원가입 API",
-            description = "로컬 로그인 방식의 회원 가입 API 입니다."
+            description = "이메일과 비밀번호를 사용한 로컬 회원가입 방식의 API입니다." + "이용약관 동의 리스트를 한꺼번에 보내주셔야합니다!"
     )
     @ApiSuccessCodeExample(resultClass = UserResponse.UserCreateResultDTO.class)
     @ApiErrorCodeExamples({
@@ -52,7 +69,7 @@ public class UserController{
     }
     @Operation(
             summary = "카카오 회원가입 API",
-            description = "카카오 소셜 로그인 방식의 회원 가입 API 입니다."
+            description = "소셜 플랫폼의 액세스 토큰을 이용한 회원가입 API입니다." + "이용약관 동의 리스트 한꺼번에 보내주셔야합니다!"
     )
     @ApiSuccessCodeExample(resultClass = UserResponse.UserCreateResultDTO.class)
     @ApiErrorCodeExamples({
@@ -70,6 +87,42 @@ public class UserController{
                 .createdAt(LocalDateTime.now())
                 .build();
 
+        return ApiResponse.onSuccess(response);
+    }
+    @Operation(
+            summary = "로컬 로그인 API",
+            description = "이메일과 비밀번호를 사용한 로컬 로그인 방식의 API입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = UserResponse.LoginResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @PostMapping("/login")
+    public ApiResponse<UserResponse.LoginResultDTO> localLogin(
+            @Valid @RequestBody UserRequest.LocalLoginDTO request
+    ){
+        UserResponse.LoginResultDTO response = UserResponse.LoginResultDTO.builder().build();
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    @Operation(
+            summary = "소셜 로그인 API",
+            description = "소셜 플랫폼의 액세스 토큰을 이용한 로그인 API입니다."
+    )
+    @ApiSuccessCodeExample(resultClass = UserResponse.LoginResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @PostMapping("/social-login")
+    public ApiResponse<UserResponse.LoginResultDTO> socialLogin(
+            @Valid @RequestBody UserRequest.SocialLoginRequest request
+    ){
+        UserResponse.LoginResultDTO response = UserResponse.LoginResultDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
@@ -1,0 +1,79 @@
+package com.server.money_touch.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class UserRequest{
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "로컬 회원가입 정보")
+    public static class LocalSignUpDTO{
+
+        @Schema(description = "닉네임", example = "잔디")
+        @NotBlank(message = "닉네임은 필수입니다")
+        private String nickname;
+
+        @Schema(description = "사진 URL", example = "http://example.com/image.jpg")
+        private String profileImgUrl;
+
+        @Schema(description = "약관동의 리스트")
+        private List<AgreementDTO> agreeTerms;
+
+        @Schema(description = "이메일", example = "example@naver.com")
+        @Email(message = "올바른 이메일 형식이어야합니다")
+        @NotBlank(message = "이메일은 필수입니다")
+        private String email;
+
+        @Schema(description = "비밀번호", example = "12345678Abc@")
+        @NotBlank(message = "비밀번호는 필수입니다")
+        private String password;
+    };
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "소셜 회원가입 정보")
+    public static class KakaoSignUpDto {
+
+        @Schema(description = "카카오 ID", example = "1234567890")
+        @NotBlank(message = "카카오 사용자 ID는 필수입니다.")
+        private String kakaoId; // 카카오에서 받은 고유 식별자
+
+        @Schema(description = "닉네임", example = "잔디")
+        @NotBlank(message = "닉네임은 필수입니다.")
+        private String nickname;
+
+        @Schema(description = "약관동의 리스트")
+        private List<AgreementDTO> agreeTerms;
+
+        @Schema(description = "사진 URL", example = "http://example.com/image.jpg")
+        private String profileImgUrl;
+
+        // 선택: 카카오에서 이메일을 제공한 경우
+        @Schema(description = "이메일", example = "example@kakao.com")
+        private String email;
+    }
+
+    @Getter
+    @Setter
+    public static class AgreementDTO {
+
+        @Schema(description = "약관 ID", example = "1")
+        @NotNull
+        private Long termsId;
+
+        @Schema(description = "동의여부", example = "true")
+        @NotNull
+        private Boolean isAgree;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
@@ -78,5 +78,4 @@ public class UserRequest{
     }
 
 
-    public static class
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
@@ -2,7 +2,6 @@ package com.server.money_touch.domain.user.dto;
 
 import com.server.money_touch.domain.user.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.user.dto;
 
+import com.server.money_touch.domain.user.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
@@ -16,8 +17,23 @@ public class UserRequest{
     @Getter
     @Setter
     @NoArgsConstructor
-    @Schema(description = "로컬 회원가입 정보")
-    public static class LocalSignUpDTO{
+    @Schema(description = "유저 상세정보 등록 요청 정보")
+    public static class UserDetailCreateDTO{
+
+        @Schema(description = "나이" , example = "20")
+        @NotBlank(message = "나이값은 필수입니다.")
+        private String age;
+
+        @Schema(description = "성별 (남성 : MALE / 여성 : FEMALE", example = "MALE")
+        private Gender gender;
+
+        @Schema(description = "직업", example = "학생")
+        @NotBlank(message = "직업값은 필수입니다.")
+        private String job;
+
+        @Schema(description = "수입 여부", example = "예")
+        @NotBlank(message = "수입 여부는 필수값입니다.")
+        private String isIncome;
 
         @Schema(description = "닉네임", example = "잔디")
         @NotBlank(message = "닉네임은 필수입니다")
@@ -25,6 +41,14 @@ public class UserRequest{
 
         @Schema(description = "사진 URL", example = "http://example.com/image.jpg")
         private String profileImgUrl;
+
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "로컬 회원가입 정보")
+    public static class LocalSignUpDTO{
 
         @Schema(description = "약관동의 리스트")
         private List<AgreementDTO> agreeTerms;
@@ -49,15 +73,8 @@ public class UserRequest{
         @NotBlank(message = "카카오 사용자 ID는 필수입니다.")
         private String kakaoId; // 카카오에서 받은 고유 식별자
 
-        @Schema(description = "닉네임", example = "잔디")
-        @NotBlank(message = "닉네임은 필수입니다.")
-        private String nickname;
-
         @Schema(description = "약관동의 리스트")
         private List<AgreementDTO> agreeTerms;
-
-        @Schema(description = "사진 URL", example = "http://example.com/image.jpg")
-        private String profileImgUrl;
 
         // 선택: 카카오에서 이메일을 제공한 경우
         @Schema(description = "이메일", example = "example@kakao.com")
@@ -66,6 +83,34 @@ public class UserRequest{
 
     @Getter
     @Setter
+    @NoArgsConstructor
+    @Schema(description = "로컬 로그인 요청 정보")
+    public static class LocalLoginDTO {
+        @Schema(description = "이메일", example = "example@naver.com")
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        private String email;
+
+        @Schema(description = "비밀번호" , example = "12345678aB!")
+        @NotBlank(message = "비밀번호는 필수입니다")
+        private String password;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "소셜 로그인 요청 정보")
+    public static class SocialLoginRequest {
+        @Schema(description = "소셜에서 발급받은 토큰", example = "asdfjqrer")
+        @NotBlank(message = "토큰값은 필수입니다.")
+        private String accessToken;
+    }
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "이용 약관 요청 정보")
     public static class AgreementDTO {
 
         @Schema(description = "약관 ID", example = "1")
@@ -76,7 +121,4 @@ public class UserRequest{
         @NotNull
         private Boolean isAgree;
     }
-
-
-    public static class
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserRequest.java
@@ -76,4 +76,7 @@ public class UserRequest{
         @NotNull
         private Boolean isAgree;
     }
+
+
+    public static class
 }

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -44,7 +44,10 @@ public class UserResponse {
         private String refreshToken;
     }
 
-
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "마이페이지 프로필 정보")
     public static class MyPageResponseDTO {
         @Schema(description = "사용자 ID", example = "1")

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -1,0 +1,26 @@
+package com.server.money_touch.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class UserResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "회원 등록 응답 정보")
+    public static class UserCreateResultDTO {
+
+        @Schema(description = "유저 id", example = "1")
+        private Long userId;
+
+        @Schema(description = "회원 생성일", example = "2021-11-08T11:44:30.327959"  )
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -23,4 +23,27 @@ public class UserResponse {
         @Schema(description = "회원 생성일", example = "2021-11-08T11:44:30.327959"  )
         private LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "유저 상세 정보 등록 응답 정보")
+    public static class UserDetailCreateResultDTO{
+
+        @Schema(description = "유저 ID", example = "1")
+        private Long userId = 1L;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "로그인 응답 정보")
+    public static class LoginResultDTO {
+        private String accessToken;
+        private String refreshToken;
+    }
+
+
 }

--- a/src/main/java/com/server/money_touch/domain/user/entity/User.java
+++ b/src/main/java/com/server/money_touch/domain/user/entity/User.java
@@ -37,5 +37,4 @@ public class User extends BaseEntity {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true) // 해당 user 삭제시 userDetail 자동삭제
     @JoinColumn(name = "user_detail_id")
     private UserDetail userDetail;
-
 }

--- a/src/main/java/com/server/money_touch/domain/user/model/UserPrincipal.java
+++ b/src/main/java/com/server/money_touch/domain/user/model/UserPrincipal.java
@@ -1,0 +1,22 @@
+//package com.server.money_touch.domain.user.model;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Getter;
+//import org.springframework.security.core.userdetails.UserDetails;
+//import java.util.Collection;
+//import org.springframework.security.core.GrantedAuthority;
+//
+//@Getter
+//@AllArgsConstructor
+//public class UserPrincipal implements UserDetails {
+//
+//    private Long id;
+//    private String username;
+//
+//    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return null; }
+//    @Override public String getPassword() { return null; }
+//    @Override public boolean isAccountNonExpired() { return true; }
+//    @Override public boolean isAccountNonLocked() { return true; }
+//    @Override public boolean isCredentialsNonExpired() { return true; }
+//    @Override public boolean isEnabled() { return true; }
+//}

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -22,7 +22,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 예산 관련 에러
     BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "BUDGET4001", "아이디와 일치하는 예산 정보를 찾을 수 없습니다."),
     TOTAL_BUDGET_EXCEEDED(HttpStatus.BAD_REQUEST, "BUDGET4002", "카테고리 예산 총합이 전체 예산을 초과합니다."),
-    TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다.");
+    TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다."),
+
+    // 소비 MBTI 관련 에러
+    MBTI_NOT_FOUND(HttpStatus.BAD_REQUEST, "MBTI4001", "해당하는 소비 MBTI가 없습니다.");
+
 
     // 소비 기록 에러
 

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -25,7 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다."),
 
     // 소비 MBTI 관련 에러
-    MBTI_NOT_FOUND(HttpStatus.BAD_REQUEST, "MBTI4001", "해당하는 소비 MBTI가 없습니다.");
+    MBTI_NOT_FOUND(HttpStatus.BAD_REQUEST, "MBTI4001", "해당하는 소비 MBTI가 없습니다."),
 
 
     // 소비 기록 에러


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#26 

## 📝 작업 내용
- 회원 & 온보딩 관련 기능에 대한 Swagger 기반 API 명세서를 작성 (컨트롤러, DTO 구현) 

## 📌 공유 사항
[x] 회원 가입 (POST) : 회원가입 + 약관 동의 로그 포함
[x] 회원 상세 정보 등록 (POST) : 온보딩을 통한 상세 정보 등록 
[x] 소비 MBTI 결과 조회 (GET)
[x] 로컬 로그인 (POST)
[x] 소셜 로그인 (POST)

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [ ] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1504" height="395" alt="image" src="https://github.com/user-attachments/assets/09609238-5cd1-4da3-85f5-cfade99df44c" />
<img width="1493" height="120" alt="image" src="https://github.com/user-attachments/assets/6915719e-02c2-4a9b-9974-8329a07e03fa" />
