### PR TITLE
[#52] Feat: 소비기록 등록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
 	// QueryDSL (Jakarta)
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.querydsl:querydsl-core:5.0.0'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
@@ -13,7 +13,7 @@ import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCate
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.user.entity.User;
-import com.server.money_touch.domain.user.respotiroy.user.UserRepository;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.global.constants.DefaultCategoryConstants;
@@ -42,7 +42,7 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
     private final BudgetCategoryRepository budgetCategoryRepository;
     private final UserRepository userRepository;
 
-    // 예산 등롥 또는 수정
+    // 예산 등록 또는 수정
     @Transactional
     @Override
     public BudgetResponse.BudgetCreateResultDTO registerOrUpdateBudgetWithCategories(Long userId, BudgetRequest.BudgetCreateDTO request) {

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -11,7 +11,7 @@ import com.server.money_touch.domain.consumptionRecord.converter.totalConsumptio
 import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
 import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
 import com.server.money_touch.domain.user.entity.User;
-import com.server.money_touch.domain.user.respotiroy.user.UserRepository;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -2,6 +2,7 @@ package com.server.money_touch.domain.consumptionRecord.controller;
 
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequest;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
+import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecordService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
@@ -24,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/consumptionrecord")
 public class ConsumptionRecordController {
 
+    private final ConsumptionRecordService consumptionRecordService;
+
     // 소비 기록 등록
     @Operation(
             summary = "소비 기록 등록 API",
@@ -34,12 +37,14 @@ public class ConsumptionRecordController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_CATEGORY_NOT_FOUND"),
     })
     @PostMapping("/record")
     public ApiResponse<ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO> postConsumptionRecord(
             @Valid @RequestBody ConsumptionRecordRequest.ConsumptionRecordCreateDTO request){
 
-        ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response = null;
+        // 유저 아이디 임시 지정
+        ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response = consumptionRecordService.createConsumptionRecord(1L, request);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionRecordResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionRecordResponse.java
@@ -5,12 +5,15 @@ import lombok.*;
 
 public class ConsumptionRecordResponse {
 
+    @Builder
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "소비 기록 등록 응답 정보")
     public static class ConsumptionRecordCreateResultDTO {
 
         @Schema(description = "소비 기록 아이디", example = "1")
-        private Long consumptionRecordId = 1L;
+        private Long consumptionRecordId;
 
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -3,14 +3,18 @@ package com.server.money_touch.domain.consumptionRecord.entity;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@Builder
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ConsumptionRecord extends BaseEntity {
 

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionCategory/ConsumptionCategoryRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionCategory/ConsumptionCategoryRepository.java
@@ -12,4 +12,6 @@ public interface ConsumptionCategoryRepository extends JpaRepository<Consumption
     Optional<ConsumptionCategory> findByUserAndBudgetCategoryNameAndBudgetCategoryType(User user, String budgetCategoryName, CategoryType type);
 
     List<ConsumptionCategory> findAllByUserAndBudgetCategoryType(User user, CategoryType type);
+
+    List<ConsumptionCategory> findAllByUser(User user);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
@@ -1,0 +1,7 @@
+package com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord;
+
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConsumptionRecordRepository extends JpaRepository<ConsumptionRecord, Long> {
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordService.java
@@ -1,0 +1,9 @@
+package com.server.money_touch.domain.consumptionRecord.service;
+
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequest;
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
+import com.server.money_touch.global.validation.annotation.ExistUser;
+
+public interface ConsumptionRecordService {
+    ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request);
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
@@ -1,0 +1,65 @@
+package com.server.money_touch.domain.consumptionRecord.service;
+
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequest;
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
+
+    private final ConsumptionRecordRepository consumptionRecordRepository;
+    private final ConsumptionCategoryRepository consumptionCategoryRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request){
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 1. 카테고리 조회
+        ConsumptionCategory category = consumptionCategoryRepository.findAllByUser(user).stream()
+                .filter(cat -> cat.getBudgetCategoryName().equals(request.getCategoryName()))
+                .findFirst()
+                .orElseThrow(()-> new GeneralException(ErrorStatus.CONSUMPTION_CATEGORY_NOT_FOUND));
+
+        // 2. 공개 여부 유효성
+        if(Boolean.TRUE.equals(request.getIsPublic())){
+            if(request.getImageUrl() == null || request.getMemo() == null){
+                throw new GeneralException(ErrorStatus._BAD_REQUEST);
+            }
+        }
+
+        // 3. 소비기록 생성
+        ConsumptionRecord record = ConsumptionRecord.builder()
+                .user(user)
+                .consumptionCategory(category)
+                .amount(request.getAmount())
+                .content(request.getContent())
+                .isPublic(request.getIsPublic() != null && request.getIsPublic())
+                .imageUrl(request.getImageUrl())
+                .memo(request.getMemo())
+                .build();
+
+        consumptionRecordRepository.save(record);
+
+        return new ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO(record.getId());
+
+
+    }
+
+
+
+}

--- a/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
+++ b/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
@@ -1,4 +1,4 @@
-package com.server.money_touch.domain.user.respotiroy.user;
+package com.server.money_touch.domain.user.repository.user;
 
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.server.money_touch.domain.user.service.user;
 
-import com.server.money_touch.domain.user.respotiroy.user.UserRepository;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #52 

## 📝 작업 내용

- 소비 기록 등록 api 구현
- isPublic(피드 등록 여부) 가 true 일 경우, imageUrl 과 memo가 null 이면 에러 반환
- isPublic 이 false 일 경우, imageUrl 또는 memo 가 선택사항이기 때문에 null 이어도 저장

## 📌 공유 사항

- user Repository 폴더명이 잘못되어 수정했습니다.
- 빌드하다가 QueryDSL 에서 오류 발생해서 build.gradle 에 의존성 추가했습니다. 오류 메시지와 의존성 추가 코드 공유합니다.
```
Caused by: java.lang.NoClassDefFoundError: com/querydsl/jpa/impl/JPAQueryFactory
QueryDSLConfig 클래스를 초기화하려 할 때 JPAQueryFactory 클래스를 찾을 수 없어서 발생한 것이라고 합니다....
```
`implementation 'com.querydsl:querydsl-core:5.0.0'`

-  아직 user 관련 api 가 구현되어 있지 않아 로컬에서 user 을 만들었습니다. 혹시 몰라서 쿼리 공유합니다.

```
INSERT INTO user (nickname, auth_type, profile_img_url, badge_id, role)
VALUES ('testuser', 'LOCAL', NULL, NULL, 'USER');

INSERT INTO user_detail (age, gender, job, is_income)
VALUES ('20대', 'FEMALE', '학생', true);

UPDATE user
SET user_detail_id = 1
WHERE id = 1;
```

- 예산 등록 시 기본 카테고리들이 만들어진다고 하여 유저 만든 후 스웨거에서 월간 예산 등록 후 소비기록 테스트했습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

<img width="1427" height="1356" alt="스크린샷 2025-07-21 163739" src="https://github.com/user-attachments/assets/f3a5737a-cf47-4b9b-91f8-fd353587a650" />
<img width="1449" height="1358" alt="스크린샷 2025-07-21 164101" src="https://github.com/user-attachments/assets/e550d017-c781-43a2-9c19-82013261e6bb" />
<img width="1435" height="1340" alt="스크린샷 2025-07-21 164406" src="https://github.com/user-attachments/assets/4e0576be-087d-4efc-a0ae-0f8a595e6e97" />


