### PR TITLE
[#55] Feat: 소비기록 카테고리 불러오기 api 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.consumptionRecord.controller;
 
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionCategoryResponse;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequest;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
 import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecordService;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "소비 기록 페이지", description = "소비 기록에 관한 API")
 @Slf4j
@@ -47,6 +50,19 @@ public class ConsumptionRecordController {
         ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response = consumptionRecordService.createConsumptionRecord(1L, request);
 
         return ApiResponse.onSuccess(response);
+    }
+
+    // 소비 카테고리 목록 조회 API
+    @Operation(summary = "소비 카테고리 목록 조회", description = "기본 + 커스텀 + 루틴 카테고리를 순서대로 반환합니다.")
+    @ApiSuccessCodeExample(resultClass = ConsumptionCategoryResponse.CategoryInfoDTO.class)
+    @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND")
+    @GetMapping("/categories")
+    public ApiResponse<List<ConsumptionCategoryResponse.CategoryInfoDTO>> getConsumptionCategories() {
+
+        // 유저 아이디 임시 지정
+        List<ConsumptionCategoryResponse.CategoryInfoDTO> categoryList =
+                consumptionRecordService.getSortedCategoriesForUser(1L);
+        return ApiResponse.onSuccess(categoryList);
     }
 
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -12,7 +12,6 @@ import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionCategoryResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionCategoryResponse.java
@@ -1,0 +1,28 @@
+package com.server.money_touch.domain.consumptionRecord.dto;
+
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ConsumptionCategoryResponse {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "소비 카테고리 정보 DTO")
+    public static class CategoryInfoDTO {
+
+        @Schema(description = "카테고리 이름", example = "배달/외식")
+        private String categoryName;
+
+        public static CategoryInfoDTO fromEntity(ConsumptionCategory category) {
+            return new CategoryInfoDTO(
+                    category.getBudgetCategoryName()
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionCategoryResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionCategoryResponse.java
@@ -1,6 +1,5 @@
 package com.server.money_touch.domain.consumptionRecord.dto;
 
-import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordService.java
@@ -1,9 +1,14 @@
 package com.server.money_touch.domain.consumptionRecord.service;
 
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionCategoryResponse;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequest;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
-import com.server.money_touch.global.validation.annotation.ExistUser;
+
+import java.util.List;
 
 public interface ConsumptionRecordService {
+
     ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request);
+
+    List<ConsumptionCategoryResponse.CategoryInfoDTO> getSortedCategoriesForUser(Long userId);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
@@ -1,6 +1,8 @@
 package com.server.money_touch.domain.consumptionRecord.service;
 
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
+import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionCategoryResponse;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequest;
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
@@ -19,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -83,6 +88,24 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
 
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<ConsumptionCategoryResponse.CategoryInfoDTO> getSortedCategoriesForUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<ConsumptionCategory> allCategories = consumptionCategoryRepository.findAllByUser(user);
+
+        return allCategories.stream()
+                .sorted(Comparator.comparingInt(cat -> {
+                    CategoryType type = cat.getBudgetCategoryType();
+                    if (type == CategoryType.DEFAULT) return 0;
+                    if (type == CategoryType.CUSTOM) return 1;
+                    return 2; // ROUTINE_CATEGORY
+                }))
+                .map(ConsumptionCategoryResponse.CategoryInfoDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
 
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #55 

## 📝 작업 내용

- 소비기록 카테고리를 보여주는 API 구현
- 기본, 커스텀, 소비 카테고리 순으로 보여줍니다.

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

<img width="1450" height="1229" alt="image" src="https://github.com/user-attachments/assets/0c96c04e-8323-4d7a-b947-89094dd4cfbb" />
