### PR TITLE
[#48] Feat: 알림 관련 기능 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/server/money_touch/domain/notification/controller/NotificationController.java
@@ -37,27 +37,18 @@ import org.springframework.web.bind.annotation.*;
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
         })
         @Parameters({
-                @Parameter(name = "cursor", description = "커서 ID (첫 조회시 null)", example = "123"),
-                @Parameter(name = "size", description = "한 번에 가져올 알림 개수", example = "20")
+                @Parameter(name = "cursor", description = "커서 ID (첫 조회시 null)", example = "123")
         })
         @GetMapping("/list")
         public ApiResponse<NotificationResponse.NotificationListDTO> getNotificationList(
-                @Parameter(description = "커서 ID (첫 조회시 null)", example = "123")
-                @RequestParam(required = false) Long cursor,
+                @Parameter(description = "커서 ID (첫 조회시 null)", example = "10")
+                @RequestParam(required = false) Long cursor) {
 
-                @Parameter(description = "한 번에 가져올 알림 개수", example = "20")
-                @RequestParam(defaultValue = "20") int size) {
-
-            // size 제한 (너무 많은 데이터 방지)
-            if (size > 100) {
-                size = 100;
-            }
-
-            log.info("알림 목록 조회 요청 - cursor: {}, size: {}", cursor, size);
+            log.info("알림 목록 조회 요청 - cursor: {}", cursor);
 
             // userId 임시로 1로 지정 (추후 JWT 토큰에서 추출)
             NotificationResponse.NotificationListDTO response =
-                    notificationService.getNotificationsByCursor(1L, cursor, size);
+                    notificationService.getNotificationsByCursor(1L, cursor);
 
             return ApiResponse.onSuccess(response);
         }

--- a/src/main/java/com/server/money_touch/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/server/money_touch/domain/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.notification.controller;
 
 import com.server.money_touch.domain.notification.dto.NotificationResponse;
+import com.server.money_touch.domain.notification.service.NotificationService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
@@ -22,10 +23,12 @@ import org.springframework.web.bind.annotation.*;
     @RequestMapping("/api/notification")
     public class NotificationController {
 
+        private final NotificationService notificationService;
+
         // 전체 알림 조회
         @Operation(
                 summary = "전체 알림 조회 API",
-                description = "사용자의 모든 알림목록을 조회하는 API입니다."
+                description = "커서 기반 무한스크롤로 사용자의 모든 알림목록을 조회하는 API입니다."
         )
 //        @ApiSuccessCodeExample(resultClass = NotificationResponse.NotificationListDTO.class)
         @ApiErrorCodeExamples({
@@ -33,9 +36,29 @@ import org.springframework.web.bind.annotation.*;
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
         })
+        @Parameters({
+                @Parameter(name = "cursor", description = "커서 ID (첫 조회시 null)", example = "123"),
+                @Parameter(name = "size", description = "한 번에 가져올 알림 개수", example = "20")
+        })
         @GetMapping("/list")
-        public ApiResponse<NotificationResponse.NotificationListDTO> getNotificationList() {
-            NotificationResponse.NotificationListDTO response = NotificationResponse.NotificationListDTO.builder().build();
+        public ApiResponse<NotificationResponse.NotificationListDTO> getNotificationList(
+                @Parameter(description = "커서 ID (첫 조회시 null)", example = "123")
+                @RequestParam(required = false) Long cursor,
+
+                @Parameter(description = "한 번에 가져올 알림 개수", example = "20")
+                @RequestParam(defaultValue = "20") int size) {
+
+            // size 제한 (너무 많은 데이터 방지)
+            if (size > 100) {
+                size = 100;
+            }
+
+            log.info("알림 목록 조회 요청 - cursor: {}, size: {}", cursor, size);
+
+            // userId 임시로 1로 지정 (추후 JWT 토큰에서 추출)
+            NotificationResponse.NotificationListDTO response =
+                    notificationService.getNotificationsByCursor(1L, cursor, size);
+
             return ApiResponse.onSuccess(response);
         }
 

--- a/src/main/java/com/server/money_touch/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/server/money_touch/domain/notification/controller/NotificationController.java
@@ -69,6 +69,8 @@ import org.springframework.web.bind.annotation.*;
 //        @ApiSuccessCodeExample(resultClass = NotificationResponse.NotificationReadResultDTO.class)
         @ApiErrorCodeExamples({
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "NOTIFICATION_NOT_FOUND"),
+                @ApiErrorCodeExample(value = ErrorStatus.class, name = "NO_PERMISSION_FOR_NOTIFICATION"),
+                @ApiErrorCodeExample(value = ErrorStatus.class, name = "ALREADY_READ_NOTIFICATION"),
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
                 @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
@@ -80,7 +82,10 @@ import org.springframework.web.bind.annotation.*;
         public ApiResponse<NotificationResponse.NotificationReadResultDTO> readNotification(
                 @PathVariable Long notificationId
         ) {
-            NotificationResponse.NotificationReadResultDTO response = NotificationResponse.NotificationReadResultDTO.builder().build();
+            log.info("알림 읽음 처리 요청 - notificationId: {}", notificationId);
+
+            // userId 임시로 1로 지정 (추후 JWT 토큰에서 추출)
+            NotificationResponse.NotificationReadResultDTO response =notificationService.markAsRead(1L, notificationId);
             return ApiResponse.onSuccess(response);
         }
     }

--- a/src/main/java/com/server/money_touch/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/server/money_touch/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,65 @@
+package com.server.money_touch.domain.notification.converter;
+
+import com.server.money_touch.domain.notification.dto.NotificationResponse;
+import com.server.money_touch.domain.notification.entity.Notification;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public class NotificationConverter {
+
+    // Notification 엔터티 -> NotificationDetailDTO
+    public static NotificationResponse.NotificationDetailDTO toNotificationDetailDTO(Notification notification) {
+
+        if(notification == null) {
+            return null;
+        }
+
+        return NotificationResponse.NotificationDetailDTO.builder()
+                .notificationId(notification.getId())
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .notificationTypeName(notification.getNotificationType().getNotificationTypeName())
+                .imgUrl(notification.getNotificationType().getImgUrl())
+                .senderId(notification.getSenderId())
+                .targetId(notification.getTargetId())
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+
+    }
+
+    // 무한스크롤용 알림 목록 DTO 변환
+    public static NotificationResponse.NotificationListDTO toNotificationListDTO(Slice<Notification> notificationSlice) {
+
+        if (notificationSlice == null) {
+            return NotificationResponse.NotificationListDTO.builder()
+                    .notificationList(List.of())
+                    .notificationListSize(0)
+                    .isFirst(true)
+                    .isLast(true)
+                    .hasNext(false)
+                    .nextCursorId(null)
+                    .build();
+        }
+
+        List<NotificationResponse.NotificationDetailDTO> detailDTOList = notificationSlice.getContent().stream()
+                .map(NotificationConverter::toNotificationDetailDTO)
+                .toList();
+
+        // 다음 커서 ID 설정 (마지막 아이템의 ID)
+        Long nextCursorId = null;
+        if (notificationSlice.hasNext() && !detailDTOList.isEmpty()) {
+            nextCursorId = detailDTOList.get(detailDTOList.size() - 1).getNotificationId();
+        }
+
+        return NotificationResponse.NotificationListDTO.builder()
+                .notificationList(detailDTOList)
+                .notificationListSize(detailDTOList.size())
+                .isFirst(notificationSlice.isFirst())
+                .isLast(notificationSlice.isLast())
+                .hasNext(notificationSlice.hasNext())
+                .nextCursorId(nextCursorId)
+                .build();
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/server/money_touch/domain/notification/dto/NotificationResponse.java
@@ -1,8 +1,12 @@
 package com.server.money_touch.domain.notification.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class NotificationResponse {
@@ -19,14 +23,17 @@ public class NotificationResponse {
         @Schema(description = "현재 페이지의 알림 개수", example = "10")
         Integer notificationListSize;
 
-        @Schema(description = "페이지 처음 여부", example = "true")
-        Boolean isFirst;
+        @Schema(description = "첫 페이지 여부", example = "true")
+        private boolean isFirst;
 
-        @Schema(description = "페이지 마지막 여부", example = "false")
-        Boolean isLast;
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        private boolean isLast;
 
-        @Schema(description = "다음 페이지가 있는지 여부", example = "true")
-        Boolean hasNext;
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private boolean hasNext;
+
+        @Schema(description = "다음 커서 ID (무한스크롤용)", example = "123")
+        private Long nextCursorId;
     }
 
     @Builder
@@ -59,6 +66,9 @@ public class NotificationResponse {
 
         @Schema(description = "읽음 여부", example = "false")
         private Boolean isRead;
+
+        @Schema(description = "알림 생성 일시", example = "2025-01-15T14:30:25")
+        private LocalDateTime createdAt;
 
     }
 

--- a/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
+++ b/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
@@ -38,4 +38,9 @@ public class Notification extends BaseEntity {
 
     @Column(nullable = false)
     private Long targetId;
+
+    // 읽음 처리
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/server/money_touch/domain/notification/repository/NotificationRepository.java
@@ -13,8 +13,10 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     /**
-     * 커서 기반 무한스크롤을 위한 알림 조회
-     * 최신순으로 정렬, 커서 ID보다 작은(이전) 알림들을 조회
+     * 커서 기반 무한스크롤로 알림 조회
+     * cursorId가 null이면 첫 페이지 조회 (모든 알림)
+     * cursorId가 있으면 해당 ID보다 작은 알림들 조회
+     * ID 기준 내림차순 정렬 (최신순)
      */
     @Query("SELECT n FROM Notification n " +
             "WHERE n.user.id = :userId " +
@@ -25,13 +27,4 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("cursorId") Long cursorId,
             Pageable pageable);
 
-    /**
-     * 첫 페이지 조회용 (커서 없이)
-     */
-    @Query("SELECT n FROM Notification n " +
-            "WHERE n.user.id = :userId " +
-            "ORDER BY n.id DESC")
-    Slice<Notification> findFirstPageNotifications(
-            @Param("userId") Long userId,
-            Pageable pageable);
 }

--- a/src/main/java/com/server/money_touch/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/server/money_touch/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,37 @@
+package com.server.money_touch.domain.notification.repository;
+
+import com.server.money_touch.domain.notification.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    /**
+     * 커서 기반 무한스크롤을 위한 알림 조회
+     * 최신순으로 정렬, 커서 ID보다 작은(이전) 알림들을 조회
+     */
+    @Query("SELECT n FROM Notification n " +
+            "WHERE n.user.id = :userId " +
+            "AND (:cursorId IS NULL OR n.id < :cursorId) " +
+            "ORDER BY n.id DESC")
+    Slice<Notification> findNotificationsByCursor(
+            @Param("userId") Long userId,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable);
+
+    /**
+     * 첫 페이지 조회용 (커서 없이)
+     */
+    @Query("SELECT n FROM Notification n " +
+            "WHERE n.user.id = :userId " +
+            "ORDER BY n.id DESC")
+    Slice<Notification> findFirstPageNotifications(
+            @Param("userId") Long userId,
+            Pageable pageable);
+}

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
@@ -8,10 +8,9 @@ public interface NotificationService {
      * 커서 기반 무한스크롤로 알림 목록 조회
      * @param userId 사용자 ID
      * @param cursorId 커서 ID (첫 조회시 null)
-     * @param size 페이지 사이즈
      * @return 알림 목록 DTO
      */
-    NotificationResponse.NotificationListDTO getNotificationsByCursor(Long userId, Long cursorId, int size);
+    NotificationResponse.NotificationListDTO getNotificationsByCursor(Long userId, Long cursorId);
 
     /**
      * 알림 읽음 처리

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
@@ -4,7 +4,13 @@ import com.server.money_touch.domain.notification.dto.NotificationResponse;
 
 public interface NotificationService {
 
-    // 무한스크롤로 알림 목록 조회
-    NotificationResponse.NotificationListDTO getNotificationList(Long userId, Integer page, Integer size);
+    /**
+     * 커서 기반 무한스크롤로 알림 목록 조회
+     * @param userId 사용자 ID
+     * @param cursorId 커서 ID (첫 조회시 null)
+     * @param size 페이지 사이즈
+     * @return 알림 목록 DTO
+     */
+    NotificationResponse.NotificationListDTO getNotificationsByCursor(Long userId, Long cursorId, int size);
 
 }

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
@@ -13,4 +13,11 @@ public interface NotificationService {
      */
     NotificationResponse.NotificationListDTO getNotificationsByCursor(Long userId, Long cursorId, int size);
 
+    /**
+     * 알림 읽음 처리
+     * @param userId 사용자 ID
+     * @param notificationId 알림 ID
+     * @return 읽음 처리 결과 DTO
+     */
+    NotificationResponse.NotificationReadResultDTO markAsRead(Long userId, Long notificationId);
 }

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationService.java
@@ -1,0 +1,10 @@
+package com.server.money_touch.domain.notification.service;
+
+import com.server.money_touch.domain.notification.dto.NotificationResponse;
+
+public interface NotificationService {
+
+    // 무한스크롤로 알림 목록 조회
+    NotificationResponse.NotificationListDTO getNotificationList(Long userId, Integer page, Integer size);
+
+}

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
@@ -22,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class NotificationServiceImpl implements NotificationService {
 
+    private static final Integer PAGE_SIZE = 10;
+
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
@@ -30,13 +32,13 @@ public class NotificationServiceImpl implements NotificationService {
      */
     @Override
     public NotificationResponse.NotificationListDTO getNotificationsByCursor(
-            Long userId, Long cursorId, int size) {
+            Long userId, Long cursorId) {
 
         // 사용자 존재 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() ->  new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Pageable pageable = PageRequest.of(0, size);
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
 
         // 하나의 메서드로 커서 기반 조회 (cursorId가 null이면 첫 페이지)
         Slice<Notification> notificationSlice =

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
@@ -2,24 +2,51 @@ package com.server.money_touch.domain.notification.service;
 
 import com.server.money_touch.domain.notification.converter.NotificationConverter;
 import com.server.money_touch.domain.notification.dto.NotificationResponse;
+import com.server.money_touch.domain.notification.entity.Notification;
+import com.server.money_touch.domain.notification.repository.NotificationRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
+@Service
 public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
 
     /**
      * 커서 기반 무한스크롤로 알림 목록 조회
      */
     public NotificationResponse.NotificationListDTO getNotificationsByCursor(
             Long userId, Long cursorId, int size) {
+
+        // 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() ->  new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<Notification> notificationSlice;
+
+        // 첫 페이지인지 확인 (cursorId가 null이면 첫 페이지)
+        if (cursorId == null) {
+            notificationSlice = notificationRepository.findFirstPageNotifications(userId, pageable);
+        } else {
+            notificationSlice = notificationRepository.findNotificationsByCursor(userId, cursorId, pageable);
+        }
+
+        // Converter 사용하여 DTO 변환
+        return NotificationConverter.toNotificationListDTO(notificationSlice);
 
     }
 }

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
@@ -36,14 +36,10 @@ public class NotificationServiceImpl implements NotificationService {
                 .orElseThrow(() ->  new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Notification> notificationSlice;
 
-        // 첫 페이지인지 확인 (cursorId가 null이면 첫 페이지)
-        if (cursorId == null) {
-            notificationSlice = notificationRepository.findFirstPageNotifications(userId, pageable);
-        } else {
-            notificationSlice = notificationRepository.findNotificationsByCursor(userId, cursorId, pageable);
-        }
+        // 하나의 메서드로 커서 기반 조회 (cursorId가 null이면 첫 페이지)
+        Slice<Notification> notificationSlice =
+                notificationRepository.findNotificationsByCursor(userId, cursorId, pageable);
 
         // Converter 사용하여 DTO 변환
         return NotificationConverter.toNotificationListDTO(notificationSlice);

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,25 @@
+package com.server.money_touch.domain.notification.service;
+
+import com.server.money_touch.domain.notification.converter.NotificationConverter;
+import com.server.money_touch.domain.notification.dto.NotificationResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class NotificationServiceImpl implements NotificationService {
+
+    /**
+     * 커서 기반 무한스크롤로 알림 목록 조회
+     */
+    public NotificationResponse.NotificationListDTO getNotificationsByCursor(
+            Long userId, Long cursorId, int size) {
+
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/notification/service/NotificationServiceImpl.java
@@ -28,6 +28,7 @@ public class NotificationServiceImpl implements NotificationService {
     /**
      * 커서 기반 무한스크롤로 알림 목록 조회
      */
+    @Override
     public NotificationResponse.NotificationListDTO getNotificationsByCursor(
             Long userId, Long cursorId, int size) {
 
@@ -45,4 +46,36 @@ public class NotificationServiceImpl implements NotificationService {
         return NotificationConverter.toNotificationListDTO(notificationSlice);
 
     }
+
+    /**
+     * 알림 읽음 처리
+     */
+    @Override
+    @Transactional
+    public NotificationResponse.NotificationReadResultDTO markAsRead(Long userId, Long notificationId) {
+
+        // 존재하는 알림인지 확인
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        // 해당 사용자의 알림인지 확인
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.NO_PERMISSION_FOR_NOTIFICATION);
+        }
+
+        // 이미 읽은 알림인지 확인
+        if (notification.getIsRead()) {
+            throw new ErrorHandler(ErrorStatus.ALREADY_READ_NOTIFICATION);
+        }
+
+        // 알림 읽음 처리
+        notification.markAsRead();
+
+        return NotificationResponse.NotificationReadResultDTO.builder()
+                .notificationId(notificationId)
+                .isRead(true)
+                .message("알림이 읽음 처리되었습니다.")
+                .build();
+    }
+
 }

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -57,7 +57,12 @@ public enum ErrorStatus implements BaseErrorCode {
     ERROR_UPLOAD_ROUTINE_IMG(HttpStatus.INTERNAL_SERVER_ERROR, "ROUTINE5001", "소비 루틴 이미지 등록에 실패하였습니다."),
 
     // 리액션 관련 에러
-    REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REACTION4001", "반응을 찾을 수 없습니다.");
+    REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REACTION4001", "반응을 찾을 수 없습니다."),
+
+    // 알림 관련 에러
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "존재하지 않는 알림입니다."),
+    NO_PERMISSION_FOR_NOTIFICATION(HttpStatus.FORBIDDEN, "NOTIFICATION4002", " 해당 알림에 접근할 권한이 없습니다."),
+    ALREADY_READ_NOTIFICATION(HttpStatus.CONFLICT, "NOTIFICATION4003", "이미 읽음 처리된 알림입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #48 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- **알림 조회 기능 구현**
    커서 기반 무한스크롤을 이용하여 사용자 알림 조회 기능을 구현하였습니다.
    - **고정 페이지 크기**: 한 번에 10개씩 조회
    - **최신순 정렬**: ID 내림차순으로 최신 알림부터 표시
    - `(:cursorId IS NULL OR n.id < :cursorId)` 조건으로 첫 페이지와 다음 페이지를 하나의 메서드로 처리히도록 리팩토링
- **알림 읽음 처리**
    - **알림 존재 확인**: `NOTIFICATION_NOT_FOUND`
    - **권한 확인**: `NO_PERMISSION_FOR_NOTIFICATION`
    - **중복 처리 확인**: `ALREADY_READ_NOTIFICATION`
    - **읽음 처리 실행**: Entity의 `markAsRead()` 메서드 호출

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
- **알림 조회**
<img width="2048" height="1344" alt="image" src="https://github.com/user-attachments/assets/be3833f1-09bb-4a67-bb64-516822972caa" />

- **알림 읽음 처리** : 해당 유저의 알림이 아닐 때 (접근 권한 X)
    
<img width="2048" height="515" alt="image" src="https://github.com/user-attachments/assets/edfd93ef-cc7c-4fd6-84ef-29d7b2968f54" />

- **알림 읽음 처리** : 이미 읽음 처리된 알림일 때
    
<img width="2048" height="750" alt="image" src="https://github.com/user-attachments/assets/2993cfc2-46d3-4dbe-a7e7-b08fc1a60a27" />

- **알림 읽음 처리** : 읽음 처리 성공
<img width="2048" height="840" alt="image" src="https://github.com/user-attachments/assets/b3101445-e440-4b8f-a5fb-52f37eefc312" />

