### PR TITLE
[#62] Feat: 똑똑 소비왕 랭킹 API 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
@@ -3,5 +3,11 @@ package com.server.money_touch.domain.consumptionRecord.repository.consumptionRe
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface ConsumptionRecordRepository extends JpaRepository<ConsumptionRecord, Long>, ConsumptionRecordRepositoryCustom {
+
+    List<ConsumptionRecord> findAllByIsPublicTrueAndCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
+++ b/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.home.controller;
 
 import com.server.money_touch.domain.home.dto.HomeResponse;
+import com.server.money_touch.domain.home.service.HomeService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
@@ -23,6 +24,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/home")
 public class HomeController {
+
+    private final HomeService homeService;
 
     @Operation(
             summary = "소비 통계 조회 API",
@@ -87,9 +90,7 @@ public class HomeController {
 
     @Operation(
             summary = "소비왕 랭킹 조회 API",
-            description = "이번 주 기준 현명해요 수가 가장 많은 유저 10명 + 내 순위를 반환합니다."+
-                    "Try it out -> Execute 로 리스트 확인 가능합니다. " +
-                    "임시 더미데이터 입력한 상태")
+            description = "지난 주 기준 현명해요 수가 가장 많은 유저 10명 + 내 순위를 반환합니다.")
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
@@ -98,25 +99,9 @@ public class HomeController {
     @GetMapping("/ranking")
     public ApiResponse<HomeResponse.WiseRankingResponseDTO> getWiseRanking() {
 
-        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
-        List<HomeResponse.RankingUserDTO> top10 = List.of(
-                new HomeResponse.RankingUserDTO("제이", "https://", 100, "SAME"),
-                new HomeResponse.RankingUserDTO("영이", "https://", 92, "UP"),
-                new HomeResponse.RankingUserDTO("앨빈", "https://", 87, "DOWN"),
-                new HomeResponse.RankingUserDTO("재현", "https://", 80, "UP"),
-                new HomeResponse.RankingUserDTO("도영", "https://", 75, "DOWN"),
-                new HomeResponse.RankingUserDTO("마크", "https://", 70, "SAME"),
-                new HomeResponse.RankingUserDTO("해찬", "https://", 60, "SAME"),
-                new HomeResponse.RankingUserDTO("유타", "https://", 55, "UP"),
-                new HomeResponse.RankingUserDTO("태용", "https://", 40, "DOWN"),
-                new HomeResponse.RankingUserDTO("정우", "https://", 35, "SAME")
-        );
+        // 임시 유저 지정
+        return ApiResponse.onSuccess(homeService.getWeeklyWiseRanking(1L));
 
-        HomeResponse.MyRankingDTO myRank = new HomeResponse.MyRankingDTO(
-                "라인", "https://", 89, 11
-        );
-
-        return ApiResponse.onSuccess(new HomeResponse.WiseRankingResponseDTO(top10, myRank));
     }
 
     @Operation(
@@ -163,6 +148,15 @@ public class HomeController {
         );
 
         return ApiResponse.onSuccess(routines);
+    }
+
+    @Operation(
+            summary = "[관리자용] 랭킹 수동 갱신 API",
+            description = "지난 주 소비 기록 기준으로 랭킹을 수동으로 계산, 저장합니다.")
+    @GetMapping("/ranking/refresh")
+    public ApiResponse<String> refreshWiseRankingManually() {
+        homeService.calculateAndSaveWeeklyWiseRanking();
+        return ApiResponse.onSuccess("주간 랭킹 수동 갱신 완료");
     }
 
 }

--- a/src/main/java/com/server/money_touch/domain/home/entity/WiseRankingHistory.java
+++ b/src/main/java/com/server/money_touch/domain/home/entity/WiseRankingHistory.java
@@ -1,0 +1,30 @@
+package com.server.money_touch.domain.home.entity;
+
+import com.server.money_touch.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class WiseRankingHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private int ranking;
+
+    private int wiseCount;
+
+    private LocalDate rankingWeekStartDate;
+
+}

--- a/src/main/java/com/server/money_touch/domain/home/repository/WiseRankingHistoryRepository.java
+++ b/src/main/java/com/server/money_touch/domain/home/repository/WiseRankingHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.server.money_touch.domain.home.repository;
+
+import com.server.money_touch.domain.home.entity.WiseRankingHistory;
+import com.server.money_touch.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface WiseRankingHistoryRepository extends JpaRepository<WiseRankingHistory,Long> {
+
+    Optional<WiseRankingHistory> findByUserAndRankingWeekStartDate(User user, LocalDate rankingWeekStartDate);
+
+    List<WiseRankingHistory> findAllByRankingWeekStartDateOrderByRankingAsc(LocalDate weekStartDate);
+
+}

--- a/src/main/java/com/server/money_touch/domain/home/service/HomeService.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/HomeService.java
@@ -1,0 +1,11 @@
+package com.server.money_touch.domain.home.service;
+
+import com.server.money_touch.domain.home.dto.HomeResponse;
+
+public interface HomeService {
+
+    HomeResponse.WiseRankingResponseDTO getWeeklyWiseRanking(Long userId);
+
+    void calculateAndSaveWeeklyWiseRanking();
+
+}

--- a/src/main/java/com/server/money_touch/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/HomeServiceImpl.java
@@ -1,0 +1,146 @@
+package com.server.money_touch.domain.home.service;
+
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
+import com.server.money_touch.domain.home.dto.HomeResponse;
+import com.server.money_touch.domain.home.entity.WiseRankingHistory;
+import com.server.money_touch.domain.home.repository.WiseRankingHistoryRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class HomeServiceImpl implements HomeService {
+
+    private final UserRepository userRepository;
+    private final ConsumptionRecordRepository consumptionRecordRepository;
+    private final WiseRankingHistoryRepository wiseRankingHistoryRepository;
+
+    @Override
+    @Transactional
+    public void calculateAndSaveWeeklyWiseRanking(){
+
+        LocalDate rankingWeekStart = LocalDate.now().minusWeeks(1).with(DayOfWeek.MONDAY);
+        LocalDate rankingWeekEnd = rankingWeekStart.plusDays(6);
+
+        // 1. 지난주 기록에서 유저별 wiseCount 합산
+        List<ConsumptionRecord> records = consumptionRecordRepository
+                .findAllByIsPublicTrueAndCreatedAtBetween(
+                        rankingWeekStart.atStartOfDay(),
+                        rankingWeekEnd.atTime(23, 59, 59));
+
+        Map<User, Integer> userWiseCountMap = new HashMap<>();
+        for (ConsumptionRecord record : records) {
+            userWiseCountMap.merge(record.getUser(), record.getWiseCount(), Integer::sum);
+        }
+
+        // 2. 내림차순 정렬, 랭킹 부여
+        List<Map.Entry<User, Integer>> sorted = userWiseCountMap.entrySet().stream()
+                .sorted((a, b) -> b.getValue().compareTo(a.getValue()))
+                .toList();
+
+        int rank = 1;
+        for(Map.Entry<User, Integer> entry : sorted){
+            User user = entry.getKey();
+            int wiseCount = entry.getValue();
+
+            // 이미 해당 주차 랭킹이 존재한다면 스킵 (덮어쓰기 방지)
+            boolean alreadyExists = wiseRankingHistoryRepository
+                    .findByUserAndRankingWeekStartDate(user, rankingWeekStart)
+                    .isPresent();
+
+            if (alreadyExists) {
+                continue;
+            }
+
+            wiseRankingHistoryRepository.save(WiseRankingHistory.builder()
+                    .user(user)
+                    .ranking(rank)
+                    .rankingWeekStartDate(rankingWeekStart)
+                    .wiseCount(wiseCount)
+                    .build());
+            rank++;
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public HomeResponse.WiseRankingResponseDTO getWeeklyWiseRanking(Long userId) {
+
+        LocalDate rankingWeekStart = LocalDate.now().minusWeeks(1).with(DayOfWeek.MONDAY);
+
+        List<WiseRankingHistory> allRankings = wiseRankingHistoryRepository
+                .findAllByRankingWeekStartDateOrderByRankingAsc(rankingWeekStart);
+
+        List<HomeResponse.RankingUserDTO> top10 = new ArrayList<>();
+        HomeResponse.MyRankingDTO myRankingDTO = null;
+
+        int currentRank = 1;
+        for (WiseRankingHistory history : allRankings) {
+            User user = history.getUser();
+            int wiseCount = history.getWiseCount();
+
+            if (currentRank <= 10) {
+                String rankStatus = getRankStatus(user, currentRank, rankingWeekStart);
+                top10.add(new HomeResponse.RankingUserDTO(
+                        user.getNickname(),
+                        user.getProfileImgUrl(),
+                        wiseCount,
+                        rankStatus
+                ));
+            }
+
+            if (user.getId().equals(userId)) {
+                myRankingDTO = new HomeResponse.MyRankingDTO(
+                        user.getNickname(),
+                        user.getProfileImgUrl(),
+                        currentRank,
+                        wiseCount
+                );
+            }
+
+            currentRank++;
+        }
+
+        if (myRankingDTO == null) {
+            // 기록이 없는 경우
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+            myRankingDTO = new HomeResponse.MyRankingDTO(
+                    user.getNickname(),
+                    user.getProfileImgUrl(),
+                    allRankings.size() + 1,
+                    0
+            );
+        }
+
+        return new HomeResponse.WiseRankingResponseDTO(top10, myRankingDTO);
+    }
+
+    private String getRankStatus(User user, int currentRank, LocalDate thisWeekStart) {
+        LocalDate lastWeekStart = thisWeekStart.minusWeeks(1);
+
+        return wiseRankingHistoryRepository.findByUserAndRankingWeekStartDate(user, lastWeekStart)
+                .map(prev -> {
+                    if (currentRank < prev.getRanking()) return "UP";
+                    if (currentRank > prev.getRanking()) return "DOWN";
+                    return "SAME";
+                }).orElse("UP"); // 순위권 밖에 존재하다 순위를 얻게 되면 UP
+    }
+
+}
+
+

--- a/src/main/java/com/server/money_touch/domain/home/service/RankingSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/RankingSchedulerService.java
@@ -1,0 +1,29 @@
+package com.server.money_touch.domain.home.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingSchedulerService {
+
+    private final HomeService homeService;
+
+    /**
+     * 매주 월요일 0시에 지난 주 소비 기록 기반 랭킹 갱신
+     */
+    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
+    public void updateWeeklyRanking() {
+        log.info("🕛 [스케줄러] Weekly Wise Ranking 계산 시작");
+        try {
+            homeService.calculateAndSaveWeeklyWiseRanking();
+            log.info("✅ [스케줄러] Weekly Wise Ranking 계산 완료");
+        } catch (Exception e) {
+            log.error("❌ [스케줄러] Weekly Wise Ranking 계산 실패: {}", e.getMessage(), e);
+        }
+    }
+
+}


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> #62 

## 📝 작업 내용

- 똑똑 소비왕 랭킹 api 구현
=> 지난 주에 작성된 게시글의 wiseCount(현명해요) 를 유저 id 로 합산하여 매주 월요일이 될 때마다 랭킹 리스트 갱신
=> 매주 월요일 00시마다 랭킹 갱신하는 스케줄러 구현
=> 등락을 표현하려면 지난 주의 랭킹 기록이 있어야 해서 WiseRankingHistory 엔티티 생성
=> 만약, 지난 주에 어떠한 순위도 없었던 사람이 순위를 얻어 상위 10명 안에 들어간다면 up 으로 표시
=> 제대로 등락이 잘 표현되는지 확인하기 위해 이번 주 날짜의 소비기록을 넣고, 다음 주에 한 번 더 테스트할 예정입니다. 

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

<img width="2286" height="182" alt="스크린샷 2025-07-22 175114" src="https://github.com/user-attachments/assets/7f5d28c9-b357-4110-872f-cb5f2523fece" />

<img width="1893" height="1375" alt="스크린샷 2025-07-22 175140" src="https://github.com/user-attachments/assets/fdff11d8-ce5e-438c-9835-7f9c9d2944e9" />
<img width="1908" height="1067" alt="스크린샷 2025-07-22 175154" src="https://github.com/user-attachments/assets/ee4e9e59-e710-42dc-a96e-b1a258dc2251" />

<img width="1984" height="859" alt="스크린샷 2025-07-22 175104" src="https://github.com/user-attachments/assets/da9e9294-dc17-4dde-8067-4804b3c5e300" />
- ranking_week_start_date 는 랭킹 집계를 하는 기간(지난 주)의 시작일

