### PR TITLE
[#67]Feat: 홈화면 소비 통계 기능 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
@@ -1,7 +1,9 @@
 package com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord;
 
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,5 +11,13 @@ import java.util.List;
 public interface ConsumptionRecordRepository extends JpaRepository<ConsumptionRecord, Long>, ConsumptionRecordRepositoryCustom {
 
     List<ConsumptionRecord> findAllByIsPublicTrueAndCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    // 이번 달 소비기록 그룹으로 묶고, 금액 합산
+    @Query("""
+    SELECT cr.consumptionCategory.budgetCategoryName, SUM(cr.amount)
+    FROM ConsumptionRecord cr
+    WHERE cr.user = :user AND cr.consumeDate BETWEEN :start AND :end
+    GROUP BY cr.consumptionCategory.budgetCategoryName """)
+    List<Object[]> findCategorySpendingBetween(User user, LocalDateTime start, LocalDateTime end);
 
 }

--- a/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
+++ b/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
@@ -2,8 +2,11 @@ package com.server.money_touch.domain.home.controller;
 
 import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.home.service.HomeService;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.GeneralException;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,13 +29,11 @@ import java.util.List;
 public class HomeController {
 
     private final HomeService homeService;
+    private final UserRepository userRepository;
 
     @Operation(
             summary = "소비 통계 조회 API",
-            description = "이번 달 상위 5개 소비 카테고리 + 기타 여부 + 최다 소비 항목 반환. " +
-                    "Try it out -> Execute 로 리스트 확인 가능합니다. " +
-                    "임시 더미데이터 입력한 상태")
-    // @ApiSuccessCodeExample(resultClass = HomeResponse.ConsumptionStatisticsTopResponseDTO.class)
+            description = "이번 달 상위 5개 소비 카테고리(카테고리명, 퍼센트) + 그외 여부 + 그외(hasothers) 퍼센트(없으면 0.0) + 최다 소비 항목 반환.")
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
@@ -42,31 +43,16 @@ public class HomeController {
     @GetMapping("/statistics")
     public ApiResponse<HomeResponse.ConsumptionStatisticsTopResponseDTO> getTopStatistics(){
 
-        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
-        List<HomeResponse.ConsumptionStatisticsDTO> top5 = List.of(
-                new HomeResponse.ConsumptionStatisticsDTO("배달/외식", 35.0),
-                new HomeResponse.ConsumptionStatisticsDTO("카페", 25.0),
-                new HomeResponse.ConsumptionStatisticsDTO("고정비", 13.0),
-                new HomeResponse.ConsumptionStatisticsDTO("패션/쇼핑", 10.0),
-                new HomeResponse.ConsumptionStatisticsDTO("교통", 10.0)
-
-        );
-
-        boolean hasOthers = true;
-        String mostSpentCategoryName = "배달/외식";
-
-        return ApiResponse.onSuccess(
-                new HomeResponse.ConsumptionStatisticsTopResponseDTO(top5, hasOthers, mostSpentCategoryName)
-        );
+        User user = userRepository.findById(1L)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        return ApiResponse.onSuccess(homeService.getTopStatistics(user));
 
     }
 
     @Operation(
-            summary = "기타 카테고리 통계 조회 API",
-            description = "'그 외'를 클릭했을 때 상위 5개를 제외한 카테고리들의 소비 퍼센트 반환. " +
-                    "Try it out -> Execute 로 리스트 확인 가능합니다. " +
-                    "임시 더미데이터 입력한 상태")
-    //@ApiSuccessCodeExample(resultClass = HomeResponse.OtherCategoryStatisticsResponseDTO.class)
+            summary = "그외 카테고리 통계 조회 API",
+            description = "'그 외'를 클릭했을 때 상위 5개를 제외한 카테고리들의 소비 퍼센트 반환"+
+                            "반올림으로 인해 그외 카테고리 퍼센트 합계시 '그외'의 전체 퍼센트와 0.1% 차이가 발생할 수 있습니다.")
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
@@ -75,16 +61,9 @@ public class HomeController {
     @GetMapping("/statistics/others")
     public ApiResponse<HomeResponse.OtherCategoryStatisticsResponseDTO> getOtherStatistics(){
 
-
-        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
-        List<HomeResponse.ConsumptionStatisticsDTO> others = List.of(
-                new HomeResponse.ConsumptionStatisticsDTO("술/유흥", 2.0),
-                new HomeResponse.ConsumptionStatisticsDTO("교육비", 2.0),
-                new HomeResponse.ConsumptionStatisticsDTO("통신비", 2.0),
-                new HomeResponse.ConsumptionStatisticsDTO("여행", 1.0)
-        );
-
-        return ApiResponse.onSuccess(new HomeResponse.OtherCategoryStatisticsResponseDTO(others));
+        User user = userRepository.findById(1L)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        return ApiResponse.onSuccess(homeService.getOtherStatistics(user));
 
     }
 

--- a/src/main/java/com/server/money_touch/domain/home/dto/HomeResponse.java
+++ b/src/main/java/com/server/money_touch/domain/home/dto/HomeResponse.java
@@ -18,7 +18,7 @@ public class HomeResponse {
         @Schema(description = "카테고리 이름", example = "배달/외식")
         private String categoryName;
 
-        @Schema(description = "소비 비율(소수점 1자리까지. 합계 100%)", example = "35")
+        @Schema(description = "소비 비율(소수점 1자리까지. 합계 100%)", example = "35.0")
         private double percentage;
     }
 
@@ -32,6 +32,9 @@ public class HomeResponse {
 
         @Schema(description = "그 외 카테고리 존재 여부", example = "true")
         private boolean hasOthers;
+
+        @Schema(description = "기타 카테고리 퍼센트 총합", example = "7.0")
+        private double othersPercent;
 
         @Schema(description = "이번 달 최다 소비 항목", example = "배달/외식")
         private String mostSpentCategoryName;

--- a/src/main/java/com/server/money_touch/domain/home/service/HomeService.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/HomeService.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.home.service;
 
 import com.server.money_touch.domain.home.dto.HomeResponse;
+import com.server.money_touch.domain.user.entity.User;
 
 public interface HomeService {
 
@@ -8,4 +9,7 @@ public interface HomeService {
 
     void calculateAndSaveWeeklyWiseRanking();
 
+    HomeResponse.ConsumptionStatisticsTopResponseDTO getTopStatistics(User user);
+
+    HomeResponse.OtherCategoryStatisticsResponseDTO getOtherStatistics(User user);
 }

--- a/src/main/java/com/server/money_touch/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/HomeServiceImpl.java
@@ -16,10 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +28,7 @@ public class HomeServiceImpl implements HomeService {
 
     @Override
     @Transactional
-    public void calculateAndSaveWeeklyWiseRanking(){
+    public void calculateAndSaveWeeklyWiseRanking() {
 
         LocalDate rankingWeekStart = LocalDate.now().minusWeeks(1).with(DayOfWeek.MONDAY);
         LocalDate rankingWeekEnd = rankingWeekStart.plusDays(6);
@@ -53,7 +50,7 @@ public class HomeServiceImpl implements HomeService {
                 .toList();
 
         int rank = 1;
-        for(Map.Entry<User, Integer> entry : sorted){
+        for (Map.Entry<User, Integer> entry : sorted) {
             User user = entry.getKey();
             int wiseCount = entry.getValue();
 
@@ -141,6 +138,123 @@ public class HomeServiceImpl implements HomeService {
                 }).orElse("UP"); // 순위권 밖에 존재하다 순위를 얻게 되면 UP
     }
 
-}
 
+    @Override
+    @Transactional(readOnly = true)
+    public HomeResponse.ConsumptionStatisticsTopResponseDTO getTopStatistics(User user) {
+
+        LocalDateTime startOfMonth = LocalDateTime.now().withDayOfMonth(1).toLocalDate().atStartOfDay();
+        LocalDateTime endOfMonth = LocalDateTime.now().plusMonths(1).withDayOfMonth(1).minusNanos(1);
+
+        // 카테고리 별로 금액 합산
+        List<Object[]> results = consumptionRecordRepository.findCategorySpendingBetween(user, startOfMonth, endOfMonth);
+
+        // 소비 기록 없다면 빈 리스트&null 반환
+        if (results.isEmpty()) {
+            return new HomeResponse.ConsumptionStatisticsTopResponseDTO(List.of(), false, 0.0,null);
+        }
+
+        // 카테고리 별로 Map 생성하고 총합 계산
+        Map<String, Integer> amountMap = new HashMap<>();
+        int total = 0;
+        for (Object[] row : results) {
+            String category = (String) row[0];
+            int amount = ((Long) row[1]).intValue();
+            amountMap.put(category, amount);
+            total += amount;
+        }
+
+        // 소비 금액 내림차순 정렬
+        List<Map.Entry<String, Integer>> sorted = new ArrayList<>(amountMap.entrySet());
+        sorted.sort((a, b) -> b.getValue().compareTo(a.getValue()));
+
+        // 상위 5개 카테고리 추출하고 퍼센트 계산(소수점 1자리, 2자리에서 반올림)
+        List<HomeResponse.ConsumptionStatisticsDTO> top5 = new ArrayList<>();
+        double percentageSum = 0.0;
+        int topCount = Math.min(5, sorted.size());
+        for (int i = 0; i < topCount; i++) {
+            Map.Entry<String, Integer> entry = sorted.get(i);
+            double percent = Math.round((entry.getValue() * 1000.0 / total)) / 10.0;
+            top5.add(new HomeResponse.ConsumptionStatisticsDTO(entry.getKey(), percent));
+            percentageSum += percent;
+        }
+
+        // 기타 카테고리 계산
+        boolean hasOthers = sorted.size() > 5;
+        double othersPercent = 0.0;
+        if (hasOthers) {
+            othersPercent = Math.round((100.0 - percentageSum) * 10.0) / 10.0;
+            percentageSum += othersPercent;
+        }
+
+        // 퍼센트 총합이 100% 되도록 오차 보정
+        double correction = Math.round((100.0 - percentageSum) * 10.0) / 10.0;
+        if (!top5.isEmpty()) {
+            HomeResponse.ConsumptionStatisticsDTO maxCategory = Collections.max(
+                    top5,
+                    Comparator.comparingDouble(HomeResponse.ConsumptionStatisticsDTO::getPercentage));
+            maxCategory.setPercentage(Math.round((maxCategory.getPercentage() + correction) * 10.0) / 10.0);
+        }
+
+        // 최다 소비 카테고리명
+        String mostSpentCategoryName = sorted.get(0).getKey();
+
+        //최종 응답
+        return new HomeResponse.ConsumptionStatisticsTopResponseDTO(
+                top5,
+                hasOthers,
+                othersPercent,
+                mostSpentCategoryName
+        );
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public HomeResponse.OtherCategoryStatisticsResponseDTO getOtherStatistics(User user) {
+
+        LocalDateTime startOfMonth = LocalDateTime.now().withDayOfMonth(1).toLocalDate().atStartOfDay();
+        LocalDateTime endOfMonth = LocalDateTime.now().plusMonths(1).withDayOfMonth(1).minusNanos(1);
+
+        // 카테고리 별 금액 합산
+        List<Object[]> results = consumptionRecordRepository.findCategorySpendingBetween(user, startOfMonth, endOfMonth);
+
+        // 소비 기록이 없다면 빈 리스트 반환
+        if (results.isEmpty()) {
+            return new HomeResponse.OtherCategoryStatisticsResponseDTO(List.of());
+        }
+
+        // 카테고리 별로 Map 생성하고 총합 계산
+        Map<String, Integer> amountMap = new HashMap<>();
+        int total = 0;
+        for (Object[] row : results) {
+            String category = (String) row[0];
+            int amount = ((Long) row[1]).intValue();
+            amountMap.put(category, amount);
+            total += amount;
+        }
+
+        // 소비 금액 내림차순 정렬
+        List<Map.Entry<String, Integer>> sorted = new ArrayList<>(amountMap.entrySet());
+        sorted.sort((a, b) -> b.getValue().compareTo(a.getValue()));
+
+        // 상위 5개를 제외한 나머지를 그외로 간주
+        int topCount = Math.min(5, sorted.size());
+        List<Map.Entry<String, Integer>> others = sorted.subList(topCount, sorted.size());
+
+        // 그외 항목이 없다면 빈 리스트 반환
+        if (others.isEmpty()) {
+            return new HomeResponse.OtherCategoryStatisticsResponseDTO(List.of());
+        }
+
+        // 그외 카테고리 개별 항목 퍼센트 계산 (소수점 1자리 반올림)
+        List<HomeResponse.ConsumptionStatisticsDTO> othersList = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : others) {
+            double percent = Math.round((entry.getValue() * 1000.0 / total)) / 10.0;
+            othersList.add(new HomeResponse.ConsumptionStatisticsDTO(entry.getKey(), percent));
+        }
+
+        return new HomeResponse.OtherCategoryStatisticsResponseDTO(othersList);
+    }
+}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #67 

## 📝 작업 내용

<img width="1917" height="215" alt="스크린샷 2025-07-23 124053" src="https://github.com/user-attachments/assets/b2bbc688-377f-492a-9359-96e940ae77fa" />

- 소비 통계 기능 구현
-> /statistics : 상위 5개 카테고리를 순차적으로 보여주고, 그외 여부, 그외 총 퍼센트, 최다 소비 카테고리 반환
-> /statistics/others : 그외 에 포함된 카테고리명, 퍼센트 반환
-> 반올림으로 소수점 1자리으로 보정하고, 총합 100%를 맞추기 때문에 간혹 그외 총 퍼센트와 /others 에 나온 카테고리들의 퍼센트 합이 0.1% 정도 오차가 생깁니다.....

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1867" height="612" alt="스크린샷 2025-07-23 134253" src="https://github.com/user-attachments/assets/a0c563df-e444-4688-b84d-392206e9c4fc" />
<img width="1859" height="392" alt="스크린샷 2025-07-23 134307" src="https://github.com/user-attachments/assets/3f0a5c0b-774a-4ac2-b1aa-04a47e1fabed" />

