### PR TITLE
[#70] Refactor: 소비기록 이미지 등록 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -6,6 +6,7 @@ import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResp
 import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecordService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.s3.S3Manager;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -14,8 +15,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -28,11 +31,13 @@ import java.util.List;
 public class ConsumptionRecordController {
 
     private final ConsumptionRecordService consumptionRecordService;
+    private final S3Manager s3Manager;
 
     // 소비 기록 등록
     @Operation(
             summary = "소비 기록 등록 API",
-            description = "소비 기록 등록 API 입니다."
+            description = "소비 기록 등록 API 입니다. 스웨거에서는 data 와 file을 같이 업로드하면 오류가 발생하기 때문에 포스트맨으로 테스트해주세요. 실제로는 정상동작합니다."+
+                    "포스트맨 테스트 방법은 노션 문서-> be 페이지에 작성해놓겠습니다."
     )
     @ApiSuccessCodeExample(resultClass = ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO.class)
     @ApiErrorCodeExamples({
@@ -41,15 +46,31 @@ public class ConsumptionRecordController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_CATEGORY_NOT_FOUND"),
     })
-    @PostMapping("/record")
+    @PostMapping(value = "/record", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO> postConsumptionRecord(
-            @Valid @RequestBody ConsumptionRecordRequest.ConsumptionRecordCreateDTO request){
+            @RequestPart("data") @Valid ConsumptionRecordRequest.ConsumptionRecordCreateDTO request,
+            @RequestPart(value = "file", required = false) MultipartFile file){
 
-        // 유저 아이디 임시 지정
-        ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response = consumptionRecordService.createConsumptionRecord(1L, request);
+        try{
+            // 이미지 업로드 처리 (dirName = "record")
+            String imageUrl = null;
+            if (file != null && !file.isEmpty()) {
+                imageUrl = s3Manager.upload(file, "record");
+            }
 
-        return ApiResponse.onSuccess(response);
+            // 소비기록 저장 (이미지 URL 포함)
+            ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response =
+                    consumptionRecordService.createConsumptionRecord(1L, request, imageUrl);
+
+            return ApiResponse.onSuccess(response);
+
+        }catch (Exception e){
+            log.error("소비 기록 등록 실패", e);
+            return ApiResponse.onFailure("S3_UPLOAD_FAIL", e.getMessage(), null);
+        }
+
     }
+
 
     // 소비 카테고리 목록 조회 API
     @Operation(summary = "소비 카테고리 목록 조회", description = "기본 + 커스텀 + 루틴 카테고리를 순서대로 반환합니다.")

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionRecordRequest.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/ConsumptionRecordRequest.java
@@ -29,14 +29,8 @@ public class ConsumptionRecordRequest {
         @Size(max=20, message = "최대 20자까지만 입력할 수 있어요.")
         private String content;
 
-        @Schema(description = "사진 URL", example = "http://example.com/image.jpg")
-        private String imageUrl;
-
         @Schema(description = "메모" , example = "마라탕 맛있었다.")
         @Size(max=1000, message = "1000자 이내로 작성해 주세요.")
         private String memo;
-
-
-
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -8,6 +8,8 @@ import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -33,7 +35,8 @@ public class ConsumptionRecord extends BaseEntity {
 
     private boolean isPublic = true;
 
-    private String imageUrl;
+    @OneToMany(mappedBy = "consumptionRecord", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionRecordImage> images = new ArrayList<>();
 
     @Column(length = 1000)
     private String memo;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecordImage.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecordImage.java
@@ -1,0 +1,25 @@
+package com.server.money_touch.domain.consumptionRecord.entity;
+
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ConsumptionRecordImage extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumption_record_id",nullable = false)
+    private ConsumptionRecord consumptionRecord;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String filePath;
+
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordImageRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordImageRepository.java
@@ -1,0 +1,7 @@
+package com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord;
+
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecordImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConsumptionRecordImageRepository extends JpaRepository<ConsumptionRecordImage, Long> {
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordService.java
@@ -8,7 +8,9 @@ import java.util.List;
 
 public interface ConsumptionRecordService {
 
-    ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request);
+    ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(
+            Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request,String imageUrl);
 
     List<ConsumptionCategoryResponse.CategoryInfoDTO> getSortedCategoriesForUser(Long userId);
 }
+

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
@@ -7,8 +7,10 @@ import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordRequ
 import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResponse;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecordImage;
 import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordImageRepository;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
 import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
 import com.server.money_touch.domain.user.entity.User;
@@ -33,10 +35,12 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
     private final ConsumptionCategoryRepository consumptionCategoryRepository;
     private final UserRepository userRepository;
     private final TotalConsumptionRepository totalConsumptionRepository;
+    private final ConsumptionRecordImageRepository consumptionRecordImageRepository;
 
     @Override
     @Transactional
-    public ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request){
+    public ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO createConsumptionRecord(
+            Long userId, ConsumptionRecordRequest.ConsumptionRecordCreateDTO request, String imageUrl){
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
@@ -49,7 +53,7 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
 
         // 2. 공개 여부 유효성
         if(Boolean.TRUE.equals(request.getIsPublic())){
-            if(request.getImageUrl() == null || request.getMemo() == null){
+            if(imageUrl == null || request.getMemo() == null){
                 throw new GeneralException(ErrorStatus._BAD_REQUEST);
             }
         }
@@ -61,7 +65,6 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
                 .amount(request.getAmount())
                 .content(request.getContent())
                 .isPublic(request.getIsPublic() != null && request.getIsPublic())
-                .imageUrl(request.getImageUrl())
                 .memo(request.getMemo())
                 .commentCount(0)
                 .wiseCount(0)
@@ -71,6 +74,17 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
                 .build();
 
         consumptionRecordRepository.save(record);
+
+
+        // 4. 이미지 엔티티 저장 (이미지가 있는 경우만)
+        if (imageUrl != null) {
+            ConsumptionRecordImage image = ConsumptionRecordImage.builder()
+                    .consumptionRecord(record)
+                    .name("record image")  // 필요 시 originalFilename 사용 가능
+                    .filePath(imageUrl)
+                    .build();
+            consumptionRecordImageRepository.save(image);
+        }
 
         // 4-1. 현재 연도와 월 기준으로 월 시작일과 종료일 계산
         LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
@@ -85,7 +99,6 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
         totalConsumption.updateAddTotalConsumptionAmount(request.getAmount());
 
         return new ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO(record.getId());
-
 
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #70 

## 📝 작업 내용

- 소비기록 등록 api 구현할 때 이미지를 s3 가 아닌 string 으로 받아오는 걸로 구현했었습니다. 따라서 s3 로 이미지 저장하는 것으로 변경했습니다.

## 📌 공유 사항

-  소비기록 등록 api 는 포스트맨으로 테스트해야 됩니다. 테스트 방법은 노션 문서-> be 페이지에 기재해놓겠습니다.
- 소비기록 이미지 엔티티를 따로 생성하고, 소비기록 엔티티에서 image_Url 삭제 후 다음과 같이 작성했습니다.
<img width="1536" height="112" alt="image" src="https://github.com/user-attachments/assets/b0973319-9fe0-4586-9bc9-21bfb5c870c4" />

- 테이블 속성이 삭제되었기 때문에 application.yml 에서 ddl-auto 를 create 로 변경하여 테이블을 새로 생성하는 것을 추천드립니다.

- DB 에 저장한 내용이 있다면 INSERT 문으로 추출하여 콘솔에 복붙하시면 됩니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

<img width="1969" height="1264" alt="스크린샷 2025-07-23 194744" src="https://github.com/user-attachments/assets/6802aa27-3740-4b9d-898c-8b54e91f3aed" />
=> 스웨거에서는 json 과 multipartFile 을 같이 못 보냅니다. 이를 해결하려면 컨버터를 생성해야 되는데, 이 경우 실제 기능은 문제 없는데 스웨거를 위해서 불필요한 컨버터를 생성하는 것 같아 포스트맨으로 테스트하는 것으로 했습니다.
=> 아래는 테스트 화면, db 에 들어온 화면입니다. 노션에 자세하게 작성하겠습니다.

<img width="1680" height="1298" alt="스크린샷 2025-07-23 194757" src="https://github.com/user-attachments/assets/eccc88ef-ee0e-4dde-b0fd-118624fbf49e" />

<img width="2055" height="352" alt="스크린샷 2025-07-23 194812" src="https://github.com/user-attachments/assets/3a2568fb-cfaa-42a8-9493-ef6d6191a9b0" />

<img width="1699" height="1162" alt="스크린샷 2025-07-23 195913" src="https://github.com/user-attachments/assets/bf6b5178-24c6-477c-a47d-3cc6ea61af5a" />

<img width="1712" height="1290" alt="스크린샷 2025-07-23 195930" src="https://github.com/user-attachments/assets/a500e8a1-9121-4aa7-bddb-e03a585ef1cb" />
