### PR TITLE
[#73] ✨Feat: 가계부 고정비 관련 기능 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
@@ -11,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @Entity
 public class BudgetCategory extends BaseEntity {
-    @Column(columnDefinition = "INT DEFAULT 0", nullable = false)
+    @Column(columnDefinition = "INT DEFAULT 0", length = 8, nullable = false)
     private Integer budgetCategoryMoney; // 예산 카테고리 금액
 
     // 카테고리별 예산-예산 다대일

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetSchedulerService.java
@@ -1,49 +1,49 @@
-package com.server.money_touch.domain.budget.service.budget;
-
-import com.server.money_touch.domain.budget.entity.Budget;
-import com.server.money_touch.domain.budget.enums.CategoryType;
-import com.server.money_touch.domain.user.entity.User;
-import com.server.money_touch.domain.user.repository.user.UserRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-@Slf4j
-@Transactional(readOnly = true)
-@Service
-@RequiredArgsConstructor
-public class BudgetSchedulerService {
-
-    private final BudgetCommandService budgetCommandService;
-    private final UserRepository userRepository;
-
-    /**
-     * 매년 1일 12에 전체 유저에 대해 기본 카테고리를 비동기로 등록
-     */
-    @Async("customAsyncExecutor")
-    @Scheduled(cron = "0 0 12 1 * *", zone = "Asia/Seoul") // 매월 1일 12:00// 매월 1일 12:00
-    public void registerMonthlyDefaultCategoryBudgets() {
-        log.info("🕛 [스케줄러] Budget, 기본 ConsumptionCategory 테이블 생성 작업 시작");
-
-        List<User> users = userRepository.getAllBy();
-        users.forEach(user ->
-                CompletableFuture.runAsync(() -> {
-                    try {
-                        Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
-                        budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
-                        log.info("✅ [스케줄러] 사용자 {}에 대한 기본 카테고리 등록 완료", user.getId());
-                    } catch (Exception e) {
-                        log.error("❌ [스케줄러] 사용자 {}에 대한 기본 카테고리 등록 실패: {}", user.getId(), e.getMessage(), e);
-                    }
-                })
-        );
-
-        log.info("🕔 [스케줄러] Budget, 기본 ConsumptionCategory 테이블 생성 전체 비동기 작업 등록 완료");
-    }
-}
+//package com.server.money_touch.domain.budget.service.budget;
+//
+//import com.server.money_touch.domain.budget.entity.Budget;
+//import com.server.money_touch.domain.budget.enums.CategoryType;
+//import com.server.money_touch.domain.user.entity.User;
+//import com.server.money_touch.domain.user.repository.user.UserRepository;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.scheduling.annotation.Async;
+//import org.springframework.scheduling.annotation.Scheduled;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.util.List;
+//import java.util.concurrent.CompletableFuture;
+//
+//@Slf4j
+//@Transactional(readOnly = true)
+//@Service
+//@RequiredArgsConstructor
+//public class BudgetSchedulerService {
+//
+//    private final BudgetCommandService budgetCommandService;
+//    private final UserRepository userRepository;
+//
+//    /**
+//     * 매년 1일 12에 전체 유저에 대해 기본 카테고리를 비동기로 등록
+//     */
+//    @Async("customAsyncExecutor")
+//    @Scheduled(cron = "0 0 12 1 * *", zone = "Asia/Seoul") // 매월 1일 12:00// 매월 1일 12:00
+//    public void registerMonthlyDefaultCategoryBudgets() {
+//        log.info("🕛 [스케줄러] Budget, 기본 ConsumptionCategory 테이블 생성 작업 시작");
+//
+//        List<User> users = userRepository.getAllBy();
+//        users.forEach(user ->
+//                CompletableFuture.runAsync(() -> {
+//                    try {
+//                        Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
+//                        budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
+//                        log.info("✅ [스케줄러] 사용자 {}에 대한 기본 카테고리 등록 완료", user.getId());
+//                    } catch (Exception e) {
+//                        log.error("❌ [스케줄러] 사용자 {}에 대한 기본 카테고리 등록 실패: {}", user.getId(), e.getMessage(), e);
+//                    }
+//                })
+//        );
+//
+//        log.info("🕔 [스케줄러] Budget, 기본 ConsumptionCategory 테이블 생성 전체 비동기 작업 등록 완료");
+//    }
+//}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
@@ -40,15 +40,20 @@ public class ConsumptionRecordConverter {
     }
 
     // 일일 소비 기럭 내역 조회 응답
-    public static HouseholdConsumptionResponse.DailyConsumptionDetailDTO toDailyConsumptionDetailDTO(ConsumptionRecord consumptionRecord, ConsumptionCategory consumptionCategory){
+    public static HouseholdConsumptionResponse.DailyConsumptionDetailDTO toDailyConsumptionDetailDTO(
+            ConsumptionRecord record, ConsumptionCategory category) {
+
+        String categoryName = record.getIsFixed() ? "고정비" : category.getBudgetCategoryName();
+
         return HouseholdConsumptionResponse.DailyConsumptionDetailDTO.builder()
-                .categoryName(consumptionCategory.getBudgetCategoryName())
-                .amount(consumptionRecord.getAmount())
-                .content(consumptionRecord.getContent())
-                .memo(consumptionRecord.getMemo())
-                .consumeDate(consumptionRecord.getConsumeDate())
+                .amount(record.getAmount())
+                .content(record.getContent())
+                .memo(record.getMemo())
+                .consumeDate(record.getConsumeDate())
+                .categoryName(categoryName)
                 .build();
     }
+
 
     // 달력 - 특정 날짜의 소비 내역 조회 응답
     public static HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO toCalendarDailyConsumeDetailDTO(

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
@@ -6,9 +6,11 @@ import com.server.money_touch.domain.consumptionRecord.dto.HouseholdConsumptionR
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
 import com.server.money_touch.domain.consumptionRecord.projection.DailyConsumptionItemProjection;
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.user.entity.User;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ConsumptionRecordConverter {
@@ -93,6 +95,24 @@ public class ConsumptionRecordConverter {
                 .categoryName(projection.getCategoryName())
                 .content(projection.getContent())
                 .amount(projection.getAmount())
+                .build();
+    }
+
+    // 고정비용 소비 기록 생성
+    public static ConsumptionRecord toConsumptionRecordForFix(User user, ConsumptionCategory consumptionCategory, FixedConsumption fixedConsumption, LocalDateTime startOfMonth){
+        return ConsumptionRecord.builder()
+                .user(user)
+                .consumptionCategory(consumptionCategory)
+                .amount(fixedConsumption.getFixedConsumptionAmount())
+                .content(fixedConsumption.getFixedConsumptionContent())
+                .memo(fixedConsumption.getFixedConsumptionMemo())
+                .consumeDate(startOfMonth)
+                .isPublic(true) // 가계부에만 등록
+                .isFixed(true) // 고정비 여부
+                .commentCount(0)
+                .wiseCount(0)
+                .wasteCount(0)
+                .viewCount(0)
                 .build();
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -53,7 +53,11 @@ public class ConsumptionRecord extends BaseEntity {
     @ColumnDefault("0")
     private Integer viewCount = 0;
 
-    private LocalDateTime consumeDate; // 일일 소비 기록 날짜
+    private LocalDateTime consumeDate; // 소비 기록 날짜
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
+    @Builder.Default
+    private Boolean isFixed = false; // 고정비 여부
 
     // 일일 소비 기록 수정
     public void updateDailyConsumptionRecord(ConsumptionCategory category, int amount, String content, String memo, LocalDateTime consumeDate) {

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionCategory/ConsumptionCategoryRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionCategory/ConsumptionCategoryRepository.java
@@ -28,4 +28,6 @@ public interface ConsumptionCategoryRepository extends JpaRepository<Consumption
     // 요청한 이름 목록에 해당하는 소비 카테고리를 userId 기준으로 조회
     @Query("SELECT c FROM ConsumptionCategory c WHERE c.user.id = :userId AND c.budgetCategoryName IN :names")
     List<ConsumptionCategory> findAllByUserIdAndNames(@Param("userId") Long userId, @Param("names") List<String> names);
+
+    List<ConsumptionCategory> findAllByUserAndBudgetCategoryType(User user, CategoryType type);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
@@ -55,7 +55,9 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
                 .select(Projections.fields(
                         DailyConsumptionItemDetailProjection.class,
                         record.id.as("consumptionRecordId"),
-                        category.budgetCategoryName.as("categoryName"),
+                        Expressions.cases()
+                                .when(record.isFixed.isTrue()).then("고정비")
+                                .otherwise(category.budgetCategoryName).as("categoryName"),
                         record.content,
                         record.amount
                 ))
@@ -129,7 +131,9 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
                         DailyConsumptionItemProjection.class,
                         record.id.as("consumptionRecordId"),
                         record.consumeDate,
-                        category.budgetCategoryName.as("categoryName"),
+                        Expressions.cases()
+                                .when(record.isFixed.isTrue()).then("고정비")
+                                .otherwise(category.budgetCategoryName).as("categoryName"),
                         record.content,
                         record.amount
                 ))

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.server.money_touch.domain.consumptionRecord.entity.QConsumptionRecord
 import com.server.money_touch.domain.consumptionRecord.projection.DailyAmountProjection;
 import com.server.money_touch.domain.consumptionRecord.projection.DailyConsumptionItemDetailProjection;
 import com.server.money_touch.domain.consumptionRecord.projection.DailyConsumptionItemProjection;
+import com.server.money_touch.domain.fixedConsumption.entity.QFixedConsumption;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -30,6 +31,7 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
 
     QConsumptionRecord record = QConsumptionRecord.consumptionRecord;
     QConsumptionCategory category = QConsumptionCategory.consumptionCategory;
+    QFixedConsumption fixed = QFixedConsumption.fixedConsumption;
 
     /**
      * 사용자의 특정 날짜에 해당하는 소비 기록 목록을 조회합니다.

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
@@ -35,7 +35,7 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
     private final ConsumptionRecordRepository consumptionRecordRepository;
     private final UserRepository userRepository;
     private final ConsumptionCategoryRepository consumptionCategoryRepository;
-    private static final Integer PAGE_SIZE = 15;
+    private static final Integer PAGE_SIZE = 10;
 
     // 소비 기록 존재 여부 검증
     @Override

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/totalConsumption/TotalConsumptionSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/totalConsumption/TotalConsumptionSchedulerService.java
@@ -1,58 +1,58 @@
-package com.server.money_touch.domain.consumptionRecord.service.totalConsumption;
-
-
-import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
-import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
-import com.server.money_touch.domain.user.entity.User;
-import com.server.money_touch.domain.user.repository.user.UserRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class TotalConsumptionSchedulerService {
-
-    private final UserRepository userRepository;
-    private final TotalConsumptionRepository totalConsumptionRepository;
-
-    /**
-     * 매년 1일 12시에 전체 유저의 월별 총 소비 금액을 비동기로 생성
-     */
-    @Async("customAsyncExecutor")
-    @Scheduled(cron = "0 0 12 1 * *", zone = "Asia/Seoul") // 매월 1일 12:00
-    public void generateMonthlyTotalConsumption() {
-        log.info("🕛 [스케줄러] TotalConsumption 총 소비 금액 테이블 생성 작업 시작");
-
-        List<User> users = userRepository.getAllBy();
-        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
-        users.forEach(user -> CompletableFuture.runAsync(() -> {
-            try {
-                boolean exists = totalConsumptionRepository
-                        .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                        .isPresent();
-
-                if (!exists) {
-                    totalConsumptionRepository.save(TotalConsumptionConverter.toTotalConsumption(user));
-                    log.info("✅ 사용자 {}의 총 소비 금액 생성 완료", user.getId());
-                } else {
-                    log.info("⏭ 사용자 {}의 총 소비 금액은 이미 존재함", user.getId());
-                }
-            } catch (Exception e) {
-                log.error("❌ 사용자 {} 총 소비 금액 생성 실패: {}", user.getId(), e.getMessage(), e);
-            }
-        }));
-
-        log.info("🕔 [스케줄러] TotalConsumption 총 소비 금액 테이블 생성 전체 비동기 작업 등록 완료");
-    }
-}
+//package com.server.money_touch.domain.consumptionRecord.service.totalConsumption;
+//
+//
+//import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
+//import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
+//import com.server.money_touch.domain.user.entity.User;
+//import com.server.money_touch.domain.user.repository.user.UserRepository;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.scheduling.annotation.Async;
+//import org.springframework.scheduling.annotation.Scheduled;
+//import org.springframework.stereotype.Service;
+//
+//import java.time.LocalDate;
+//import java.time.LocalDateTime;
+//import java.util.List;
+//import java.util.concurrent.CompletableFuture;
+//
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
+//public class TotalConsumptionSchedulerService {
+//
+//    private final UserRepository userRepository;
+//    private final TotalConsumptionRepository totalConsumptionRepository;
+//
+//    /**
+//     * 매년 1일 12시에 전체 유저의 월별 총 소비 금액을 비동기로 생성
+//     */
+//    @Async("customAsyncExecutor")
+//    @Scheduled(cron = "0 0 12 1 * *", zone = "Asia/Seoul") // 매월 1일 12:00
+//    public void generateMonthlyTotalConsumption() {
+//        log.info("🕛 [스케줄러] TotalConsumption 총 소비 금액 테이블 생성 작업 시작");
+//
+//        List<User> users = userRepository.getAllBy();
+//        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+//        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
+//
+//        users.forEach(user -> CompletableFuture.runAsync(() -> {
+//            try {
+//                boolean exists = totalConsumptionRepository
+//                        .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
+//                        .isPresent();
+//
+//                if (!exists) {
+//                    totalConsumptionRepository.save(TotalConsumptionConverter.toTotalConsumption(user));
+//                    log.info("✅ 사용자 {}의 총 소비 금액 생성 완료", user.getId());
+//                } else {
+//                    log.info("⏭ 사용자 {}의 총 소비 금액은 이미 존재함", user.getId());
+//                }
+//            } catch (Exception e) {
+//                log.error("❌ 사용자 {} 총 소비 금액 생성 실패: {}", user.getId(), e.getMessage(), e);
+//            }
+//        }));
+//
+//        log.info("🕔 [스케줄러] TotalConsumption 총 소비 금액 테이블 생성 전체 비동기 작업 등록 완료");
+//    }
+//}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -3,6 +3,7 @@ package com.server.money_touch.domain.fixedConsumption.controller;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
 import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionCommandService;
+import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 public class FixedConsumptionController {
 
     private final FixedConsumptionCommandService fixedConsumptionCommandService;
+    private final FixedConsumptionQueryService fixedConsumptionQueryService;
 
     @Operation(
             summary = "고정비 등록 API",
@@ -89,4 +91,24 @@ public class FixedConsumptionController {
         fixedConsumptionCommandService.deleteFixedConsumption(1L, fixedConsumptionId);
         return ApiResponse.onSuccess("고정비 삭제 성공");
     }
+
+    @Operation(
+            summary = "고정비 목록 조회 API",
+            description = "사용자의 고정비 목록을 커서 기반 무한스크롤로 조회하는 API 입니다. 커서를 쿼리 파라미터로 입력해 주세요."
+    )
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
+    })
+    @Parameters({
+            @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 consumptionRecordId). 첫 요청 시 생략", example = "3", required = false)
+    })
+    @GetMapping("list")
+    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCursorResultDTO> getFixedConsumptions(@RequestParam(required = false) Long cursorId) {
+        // 로그인 전까지 userId 1로 임시 세팅
+        FixedConsumptionResponse.FixedConsumptionCursorResultDTO response = fixedConsumptionQueryService.getFixedConsumptions(1L, cursorId);
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -64,6 +64,8 @@ public class FixedConsumptionController {
     @PatchMapping("/{fixedConsumptionId}")
     public ApiResponse<String> patchFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request,
                                                @PathVariable Long fixedConsumptionId) {
+        // 로그인 전까지 userId 1로 임시 세팅
+        fixedConsumptionCommandService.updateFixedConsumption(1L, fixedConsumptionId, request);
         return ApiResponse.onSuccess("고정비 수정 성공");
     }
 
@@ -83,6 +85,8 @@ public class FixedConsumptionController {
     })
     @DeleteMapping("/{fixedConsumptionId}")
     public ApiResponse<String> deleteFixedConsumption(@PathVariable Long fixedConsumptionId) {
+        // 로그인 전까지 userId 1로 임시 세팅
+        fixedConsumptionCommandService.deleteFixedConsumption(1L, fixedConsumptionId);
         return ApiResponse.onSuccess("고정비 삭제 성공");
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -2,6 +2,7 @@ package com.server.money_touch.domain.fixedConsumption.controller;
 
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionCommandService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
@@ -25,6 +26,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/house-holds/fixed-consumptions")
 public class FixedConsumptionController {
 
+    private final FixedConsumptionCommandService fixedConsumptionCommandService;
+
     @Operation(
             summary = "고정비 등록 API",
             description = "고정비 등록 API 입니다. 금액, 카테고리, 항목명, 메모를 RequestBody로 입력받아 고정비를 등록합니다."
@@ -32,12 +35,14 @@ public class FixedConsumptionController {
     @ApiSuccessCodeExample(resultClass = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_CATEGORY_NAME_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @PostMapping()
     public ApiResponse<FixedConsumptionResponse.FixedConsumptionCreateResultDTO> postFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request) {
-        FixedConsumptionResponse.FixedConsumptionCreateResultDTO response = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.builder().build();
+        // 로그인 전까지 userId 1로 임시 세팅
+        FixedConsumptionResponse.FixedConsumptionCreateResultDTO response = fixedConsumptionCommandService.saveFixedConsumption(1L, request);
         return ApiResponse.onSuccess(response);
     }
 
@@ -45,7 +50,7 @@ public class FixedConsumptionController {
     @Operation(
             summary = "고정비 수정 API",
             description = "고정비 ID를 통해 등록된 항목을 찾아, 금액·카테고리·항목명·메모를 수정하는 API입니다. " +
-                    "ID는 Path 파라미터로, 수정 정보는 RequestBody로 입력받습니다."
+                    "ID는 PathVariable로, 수정 정보는 RequestBody로 입력받습니다."
     )
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
@@ -5,6 +5,8 @@ import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRespon
 import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.user.entity.User;
 
+import java.util.List;
+
 public class FixedConsumptionConverter {
 
     // 고정비 엔티티 생성
@@ -22,6 +24,33 @@ public class FixedConsumptionConverter {
     public static FixedConsumptionResponse.FixedConsumptionCreateResultDTO toFixedConsumptionCreateResultDTO(Long fixedConsumptionId) {
         return FixedConsumptionResponse.FixedConsumptionCreateResultDTO.builder()
                 .fixedConsumptionId(fixedConsumptionId)
+                .build();
+    }
+
+    // FixedConsumption → FixedConsumptionDetailDTO 변환
+    public static FixedConsumptionResponse.FixedConsumptionDetailDTO toFixedConsumptionDetailDTO(FixedConsumption entity) {
+        return FixedConsumptionResponse.FixedConsumptionDetailDTO.builder()
+                .fixedConsumptionId(entity.getId())
+                .categoryName(entity.getCategoryName())
+                .amount(entity.getFixedConsumptionAmount())
+                .memo(entity.getFixedConsumptionMemo())
+                .build();
+    }
+
+    // FixedConsumptionDetailDTO -> FixedConsumptionCursorResultDTO로 변환
+    public static FixedConsumptionResponse.FixedConsumptionCursorResultDTO toFixedConsumptionCursorResultDTO(
+            List<FixedConsumptionResponse.FixedConsumptionDetailDTO> content,
+            boolean hasNext,
+            Long nextCursorId,
+            boolean isFirst
+    ) {
+        return FixedConsumptionResponse.FixedConsumptionCursorResultDTO.builder()
+                .fixedConsumptions(content)
+                .fixedConsumptionSize(content.size())
+                .isFirst(isFirst)
+                .isLast(!hasNext)
+                .hasNext(hasNext)
+                .nextCursorId(nextCursorId)
                 .build();
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
@@ -1,0 +1,27 @@
+package com.server.money_touch.domain.fixedConsumption.converter;
+
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
+import com.server.money_touch.domain.user.entity.User;
+
+public class FixedConsumptionConverter {
+
+    // 고정비 엔티티 생성
+    public static FixedConsumption toFixedConsumption(User user, FixedConsumptionRequest.FixedConsumptionCreateDTO requestDTO) {
+        return FixedConsumption.builder()
+                .user(user)
+                .categoryName(requestDTO.getCategoryName())
+                .fixedConsumptionAmount(requestDTO.getAmount())
+                .fixedConsumptionContent(requestDTO.getContent())
+                .fixedConsumptionMemo(requestDTO.getMemo())
+                .build();
+    }
+
+    // 고정비 등록 응답 생성
+    public static FixedConsumptionResponse.FixedConsumptionCreateResultDTO toFixedConsumptionCreateResultDTO(Long fixedConsumptionId) {
+        return FixedConsumptionResponse.FixedConsumptionCreateResultDTO.builder()
+                .fixedConsumptionId(fixedConsumptionId)
+                .build();
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionRequest.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionRequest.java
@@ -19,7 +19,7 @@ public class FixedConsumptionRequest {
         @NotNull(message = "고정비 금액은 필수입니다.")
         private Integer amount;
 
-        @Schema(description = "소비 카테고리 이름", example = "배달/외식")
+        @Schema(description = "소비 카테고리 이름", example = "기타")
         @NotNull(message = "소비 카테고리 이름은 필수입니다.")
         private String categoryName;
 

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionResponse.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionResponse.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class FixedConsumptionResponse {
 
     @Builder
@@ -16,5 +18,50 @@ public class FixedConsumptionResponse {
     public static class FixedConsumptionCreateResultDTO {
         @Schema(description = "고정비 아이디", example = "1")
         private Long fixedConsumptionId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "고정비 조회 목록 응답 정보")
+    public static class FixedConsumptionCursorResultDTO {
+
+        @Schema(description = "고정비 목록")
+        private List<FixedConsumptionDetailDTO> fixedConsumptions;
+
+        @Schema(description = "고정비 목록 총 개수", example = "25")
+        private Integer fixedConsumptionSize;
+
+        @Schema(description = "첫 페이지 여부", example = "true")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        private Boolean isLast;
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private Boolean hasNext;
+
+        @Schema(description = "다음 요청에 사용할 커서 (마지막 고정비 ID)", example = "3")
+        private Long nextCursorId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "고정비 조회 목록 세부 응답 정보")
+    public static class FixedConsumptionDetailDTO {
+        @Schema(description = "고정비 아이디", example = "1")
+        private Long fixedConsumptionId;
+
+        @Schema(description = "소비 카테고리 이름", example = "기타")
+        private String categoryName;
+
+        @Schema(description = "고정비 금액", example = "23000")
+        private Integer amount;
+
+        @Schema(description = "메모", example = "가족 공유 요금제")
+        private String memo;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
@@ -28,8 +28,10 @@ public class FixedConsumption extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-//    // 고정비-카테고리별 예산 다대일
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "budget_category_id")
-//    private BudgetCategory budgetCategory;
+    public void updateInfo(Integer amount, String content, String memo, String categoryName) {
+        this.fixedConsumptionAmount = amount;
+        this.fixedConsumptionContent = content;
+        this.fixedConsumptionMemo = memo;
+        this.categoryName = categoryName;
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
@@ -1,6 +1,5 @@
 package com.server.money_touch.domain.fixedConsumption.entity;
 
-import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
@@ -21,13 +20,16 @@ public class FixedConsumption extends BaseEntity {
     @Column(nullable = false, length = 1000)
     private String fixedConsumptionMemo;
 
+    @Column(nullable = false, length = 20)
+    private String categoryName;
+
     // 고정비-유저 다대일 연관관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // 고정비-카테고리별 예산 다대일
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "budget_category_id")
-    private BudgetCategory budgetCategory;
+//    // 고정비-카테고리별 예산 다대일
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "budget_category_id")
+//    private BudgetCategory budgetCategory;
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface FixedConsumptionRepository extends JpaRepository<FixedConsumption, Long> {
+public interface FixedConsumptionRepository extends JpaRepository<FixedConsumption, Long>, FixedConsumptionRepositoryCustom {
     List<FixedConsumption> findAllByUser(User user);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
@@ -1,0 +1,11 @@
+package com.server.money_touch.domain.fixedConsumption.repository;
+
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
+import com.server.money_touch.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FixedConsumptionRepository extends JpaRepository<FixedConsumption, Long> {
+    List<FixedConsumption> findAllByUser(User user);
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.server.money_touch.domain.fixedConsumption.repository;
+
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public interface FixedConsumptionRepositoryCustom {
+    // 커서 기반 고정비 목록 조회
+    Slice<FixedConsumption> findFixedConsumptionsByCursor(Long userId, Long cursorId, Pageable pageable);
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.server.money_touch.domain.fixedConsumption.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
+import com.server.money_touch.domain.fixedConsumption.entity.QFixedConsumption;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class FixedConsumptionRepositoryImpl implements FixedConsumptionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    QFixedConsumption fixed = QFixedConsumption.fixedConsumption;
+
+    // 커서 기반 고정비 목록 조회
+    @Override
+    public Slice<FixedConsumption> findFixedConsumptionsByCursor(Long userId, Long cursorId, Pageable pageable) {
+        BooleanBuilder condition = new BooleanBuilder();
+        condition.and(fixed.user.id.eq(userId));
+        if (cursorId != null) {
+            condition.and(fixed.id.lt(cursorId)); // id 역순으로 작아야 이후 커서
+        }
+
+        int pageSize = pageable.getPageSize();
+        List<FixedConsumption> results = queryFactory
+                .selectFrom(fixed)
+                .where(condition)
+                .orderBy(fixed.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        boolean hasNext = results.size() > pageSize;
+        if (hasNext) {
+            results.remove(pageSize); // Slice에 반환할 범위까지만 유지
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
@@ -2,10 +2,17 @@ package com.server.money_touch.domain.fixedConsumption.service;
 
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.global.validation.annotation.ExistFixedConsumption;
 import com.server.money_touch.global.validation.annotation.ExistUser;
 
 public interface FixedConsumptionCommandService {
-
     // 고정비 등록
     FixedConsumptionResponse.FixedConsumptionCreateResultDTO saveFixedConsumption(@ExistUser Long userId, FixedConsumptionRequest.FixedConsumptionCreateDTO request);
+
+    // 고정비 수정
+    void updateFixedConsumption(
+            @ExistUser Long userId, @ExistFixedConsumption Long fixedConsumptionId, FixedConsumptionRequest.FixedConsumptionCreateDTO request);
+
+    // 고정비 삭제
+    void deleteFixedConsumption(@ExistUser Long userId, @ExistFixedConsumption Long fixedConsumptionId);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
@@ -1,0 +1,11 @@
+package com.server.money_touch.domain.fixedConsumption.service;
+
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.global.validation.annotation.ExistUser;
+
+public interface FixedConsumptionCommandService {
+
+    // 고정비 등록
+    FixedConsumptionResponse.FixedConsumptionCreateResultDTO saveFixedConsumption(@ExistUser Long userId, FixedConsumptionRequest.FixedConsumptionCreateDTO request);
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
@@ -48,4 +48,50 @@ public class FixedConsumptionCommandServiceImpl implements FixedConsumptionComma
         return FixedConsumptionConverter.toFixedConsumptionCreateResultDTO(fixedConsumption.getId());
     }
 
+    // 고정비 수정
+    @Transactional
+    @Override
+    public void updateFixedConsumption(
+            Long userId, Long fixedConsumptionId, FixedConsumptionRequest.FixedConsumptionCreateDTO request) {
+
+        // 카테고리 이름 유효성 검사 - 고정비는 기본 소비 카테고리만 등록 가능
+        if (!DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.contains(request.getCategoryName())) {
+            throw new ErrorHandler(ErrorStatus.CONSUMPTION_CATEGORY_NAME_NOT_FOUND);
+        }
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 기존 고정비 조회 및 사용자 일치 확인
+        FixedConsumption fixedConsumption = fixedConsumptionRepository.findById(fixedConsumptionId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.FIXED_CONSUMPTION_NOT_FOUND));
+
+        // 고정비 정보 수정
+        fixedConsumption.updateInfo(
+                request.getAmount(),
+                request.getContent(),
+                request.getMemo(),
+                request.getCategoryName()
+        );
+
+        log.info("고정비 수정 완료 - userId: {}, fixedConsumptionId: {}", userId, fixedConsumption.getId());
+    }
+
+    // 고정비 삭제
+    @Transactional
+    @Override
+    public void deleteFixedConsumption(Long userId, Long fixedConsumptionId) {
+        // 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 고정비 존재 여부 및 사용자 일치 확인
+        FixedConsumption fixedConsumption = fixedConsumptionRepository.findById(fixedConsumptionId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.FIXED_CONSUMPTION_NOT_FOUND));
+
+        fixedConsumptionRepository.delete(fixedConsumption);
+        log.info("고정비 삭제 완료 - userId: {}, fixedConsumptionId: {}", userId, fixedConsumptionId);
+    }
+
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
@@ -1,0 +1,51 @@
+package com.server.money_touch.domain.fixedConsumption.service;
+
+import com.server.money_touch.domain.fixedConsumption.converter.FixedConsumptionConverter;
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
+import com.server.money_touch.domain.fixedConsumption.repository.FixedConsumptionRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.constants.DefaultCategoryConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class FixedConsumptionCommandServiceImpl implements FixedConsumptionCommandService {
+    private final FixedConsumptionRepository fixedConsumptionRepository;
+    private final UserRepository userRepository;
+
+    // 고정비 등록
+    @Transactional
+    @Override
+    public FixedConsumptionResponse.FixedConsumptionCreateResultDTO saveFixedConsumption(
+            Long userId, FixedConsumptionRequest.FixedConsumptionCreateDTO request) {
+        // 카테고리 이름 유효성 검사 - 고정비는 기본 소비 카테고리만 등록 가능
+        if (!DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.contains(request.getCategoryName())) {
+            throw new ErrorHandler(ErrorStatus.CONSUMPTION_CATEGORY_NAME_NOT_FOUND);
+        }
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 고정비 생성 및 저장
+        FixedConsumption fixedConsumption = FixedConsumptionConverter.toFixedConsumption(user, request);
+        fixedConsumptionRepository.save(fixedConsumption);
+
+        log.info("고정비 등록 완료 - userId: {}, fixedConsumptionId: {}", userId, fixedConsumption.getId());
+        return FixedConsumptionConverter.toFixedConsumptionCreateResultDTO(fixedConsumption.getId());
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryService.java
@@ -1,0 +1,6 @@
+package com.server.money_touch.domain.fixedConsumption.service;
+
+public interface FixedConsumptionQueryService {
+    // 고정비 기록 존재 여부 검증
+    Boolean existsFixedConsumptionById(Long fixedConsumptionId);
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryService.java
@@ -1,6 +1,12 @@
 package com.server.money_touch.domain.fixedConsumption.service;
 
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.global.validation.annotation.ExistUser;
+
 public interface FixedConsumptionQueryService {
     // 고정비 기록 존재 여부 검증
     Boolean existsFixedConsumptionById(Long fixedConsumptionId);
+
+    // 고정비 목록 조회 (커서 기반 무한스크롤)
+    FixedConsumptionResponse.FixedConsumptionCursorResultDTO getFixedConsumptions(@ExistUser Long userId, Long cursorId);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryServiceImpl.java
@@ -1,11 +1,24 @@
 package com.server.money_touch.domain.fixedConsumption.service;
 
+import com.server.money_touch.domain.fixedConsumption.converter.FixedConsumptionConverter;
+import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.fixedConsumption.repository.FixedConsumptionRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Validated
@@ -15,10 +28,51 @@ import org.springframework.validation.annotation.Validated;
 public class FixedConsumptionQueryServiceImpl implements FixedConsumptionQueryService {
 
     private final FixedConsumptionRepository fixedConsumptionRepository;
+    private final UserRepository userRepository;
+    private static final Integer PAGE_SIZE = 10;
 
     // 고정비 존재 여부 검증
     @Override
     public Boolean existsFixedConsumptionById(Long fixedConsumptionId) {
         return fixedConsumptionRepository.findById(fixedConsumptionId).isPresent();
+    }
+
+    /**
+     * 고정비 목록을 커서 기반으로 조회합니다.
+     * - 페이지 사이즈는 고정(PAGE_SIZE)
+     * - 커서 기반 페이징 방식으로, 마지막 조회된 고정비 ID 이후 데이터를 가져옵니다.
+     * - 응답에는 고정비 목록, 다음 커서 ID 및 페이징 정보가 포함됩니다.
+     *
+     * @param userId   사용자 ID
+     * @param cursorId 마지막으로 조회된 고정비 ID (null이면 첫 페이지)
+     * @return FixedConsumptionCursorResultDTO (고정비 목록 + 페이징 정보)
+     */
+    @Override
+    public FixedConsumptionResponse.FixedConsumptionCursorResultDTO getFixedConsumptions(Long userId, Long cursorId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+
+        // 고정비 목록 조회 (Slice)
+        Slice<FixedConsumption> slice = fixedConsumptionRepository
+                .findFixedConsumptionsByCursor(userId, cursorId, pageable);
+
+        // 고정비 엔티티 → DTO 변환
+        List<FixedConsumptionResponse.FixedConsumptionDetailDTO> content = slice.getContent().stream()
+                .map(FixedConsumptionConverter::toFixedConsumptionDetailDTO)
+                .collect(Collectors.toList());
+
+        // 다음 커서 ID 설정
+        Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getFixedConsumptionId();
+
+        log.info("고정비 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, cursorId: {}, nextCursorId: {}", userId, cursorId, nextCursorId);
+        return FixedConsumptionConverter.toFixedConsumptionCursorResultDTO(
+                content,
+                slice.hasNext(),
+                nextCursorId,
+                cursorId == null // 첫 페이지 여부
+        );
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.server.money_touch.domain.fixedConsumption.service;
+
+import com.server.money_touch.domain.fixedConsumption.repository.FixedConsumptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class FixedConsumptionQueryServiceImpl implements FixedConsumptionQueryService {
+
+    private final FixedConsumptionRepository fixedConsumptionRepository;
+
+    // 고정비 존재 여부 검증
+    @Override
+    public Boolean existsFixedConsumptionById(Long fixedConsumptionId) {
+        return fixedConsumptionRepository.findById(fixedConsumptionId).isPresent();
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
@@ -1,0 +1,111 @@
+package com.server.money_touch.domain.fixedConsumption.service;
+
+import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
+import com.server.money_touch.domain.consumptionRecord.converter.consumptionRecord.ConsumptionRecordConverter;
+import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
+import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
+import com.server.money_touch.domain.fixedConsumption.repository.FixedConsumptionRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FixedConsumptionSchedulerService {
+
+    private final UserRepository userRepository;
+    private final FixedConsumptionRepository fixedConsumptionRepository;
+    private final ConsumptionCategoryRepository consumptionCategoryRepository;
+    private final ConsumptionRecordRepository consumptionRecordRepository;
+    private final TotalConsumptionRepository totalConsumptionRepository;
+    private final BudgetCommandService budgetCommandService;
+
+    /**
+     * 매월 1일 오전 12시 실행되는 스케줄러 - 고정비를 소비 기록으로 등록
+     */
+    @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul") // 매월 1일 자정(00:00)
+    public void registerFixedConsumptionsToRecords() {
+        log.info("🕛 [스케줄러] 고정비 소비 기록 등록 작업 시작");
+
+        List<User> users = userRepository.findAllWithUserDetail();
+
+        users.forEach(this::processUserFixedConsumption);
+
+        log.info("🕔 [스케줄러] 고정비 소비 기록 등록 전체 비동기 작업 호출 완료");
+    }
+
+    /**
+     * 사용자 1명에 대한 고정비 소비 기록 등록 (비동기)
+     */
+    @Async("customAsyncExecutor")
+    @Transactional
+    public void processUserFixedConsumption(User user) {
+        try {
+            LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+            LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
+
+            // 1. Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
+            Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
+            budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
+
+            // 2. TotalConsumption 조회 or 생성
+            TotalConsumption totalConsumption = totalConsumptionRepository
+                    .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
+                    .orElseGet(() -> totalConsumptionRepository.save(
+                            TotalConsumptionConverter.toTotalConsumption(user))
+                    );
+
+            // 3. 기본 ConsumptionCategory 목록 불러오기 (카테고리 이름 기준 매핑)
+            Map<String, ConsumptionCategory> categoryMap = consumptionCategoryRepository
+                    .findAllByUserAndBudgetCategoryType(user, CategoryType.DEFAULT)
+                    .stream()
+                    .collect(Collectors.toMap(ConsumptionCategory::getBudgetCategoryName, c -> c));
+
+            // 4~6. 고정비 목록을 기반으로 소비 기록 생성 및 저장 + TotalConsumption 반영
+            fixedConsumptionRepository.findAllByUser(user).stream()
+                    .map(fc -> {
+                        String categoryName = fc.getCategoryName();
+                        ConsumptionCategory category = categoryMap.get(categoryName);
+                        if (category == null) {
+                            log.warn("❌ 고정비 카테고리 매핑 실패 - userId: {}, categoryName: {}", user.getId(), categoryName);
+                            return null;
+                        }
+
+                        // 소비 기록 생성
+                        ConsumptionRecord record = ConsumptionRecordConverter.toConsumptionRecordForFix(user, category, fc, startOfMonth);
+
+                        // TotalConsumption 금액 반영
+                        totalConsumption.updateAddTotalConsumptionAmount(fc.getFixedConsumptionAmount());
+                        totalConsumptionRepository.save(totalConsumption); // 명시적 저장
+
+                        return record;
+                    })
+                    .filter(Objects::nonNull)
+                    .forEach(consumptionRecordRepository::save);
+
+            log.info("✅ [스케줄러] 사용자 {} 고정비 소비 기록 등록 완료", user.getId());
+
+        } catch (Exception e) {
+            log.error("❌ [스케줄러] 사용자 {} 고정비 소비 기록 등록 실패: {}", user.getId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
@@ -16,7 +16,6 @@ public class RoutineConverter {
                 .user(user)
                 .budget(budget)
                 .routineName(routineCreateDTO.getRoutineName())
-                .routineContent("") // 루틴 설명은 삭제 됐기 때문에 추후 수정
                 .routineImageUrl(routineCreateDTO.getRoutineImgUrl())
                 .viewCount(0)
                 .build();

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -15,9 +15,6 @@ public class Routine extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String routineName;
 
-    @Column(length = 1000, nullable = false)
-    private String routineContent;
-
     @Column(nullable = false)
     private String routineImageUrl;
 

--- a/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
+++ b/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
@@ -2,10 +2,12 @@ package com.server.money_touch.domain.user.repository.user;
 
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     // 전체 유저 조회
-    List<User> getAllBy();
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.userDetail")
+    List<User> findAllWithUserDetail();
 }

--- a/src/main/java/com/server/money_touch/global/validation/annotation/ExistFixedConsumption.java
+++ b/src/main/java/com/server/money_touch/global/validation/annotation/ExistFixedConsumption.java
@@ -1,0 +1,20 @@
+package com.server.money_touch.global.validation.annotation;
+
+import com.server.money_touch.global.validation.validator.FixedConsumptionExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+// 고정비 존재 검증
+@Documented
+@Constraint(validatedBy = FixedConsumptionExistValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistFixedConsumption{
+    String message() default "아이디와 일치하는 고정비가 없습니다."; // 기본 에러 메시지
+
+    Class<?>[] groups() default {}; // 유효성 검사 그룹
+
+    Class<? extends Payload>[] payload() default {}; // 메타데이터 전달용
+}

--- a/src/main/java/com/server/money_touch/global/validation/validator/FixedConsumptionExistValidator.java
+++ b/src/main/java/com/server/money_touch/global/validation/validator/FixedConsumptionExistValidator.java
@@ -1,8 +1,10 @@
 package com.server.money_touch.global.validation.validator;
 
 import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecordQueryService;
+import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionQueryService;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ExistConsumptionRecord;
+import com.server.money_touch.global.validation.annotation.ExistFixedConsumption;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
@@ -13,24 +15,23 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class ConsumptionRecordExistValidator implements ConstraintValidator<ExistConsumptionRecord,Long> {
-
-    private final ConsumptionRecordQueryService consumptionRecordQueryService;
+public class FixedConsumptionExistValidator implements ConstraintValidator<ExistFixedConsumption,Long> {
+    private final FixedConsumptionQueryService fixedConsumptionQueryService;
 
     @Override
-    public void initialize(ExistConsumptionRecord constraintAnnotation) {
+    public void initialize(ExistFixedConsumption constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
     }
 
     @Override
     public boolean isValid(Long value, ConstraintValidatorContext context) {
         // 파라미터로 넘어온 소비 기록 아이디가 존재하는 아이디인지 검증
-        boolean isValid = consumptionRecordQueryService.existsConsumptionRecordById(value);
-        log.info("ExistConsumptionRecord consumptionRecordId: {}, isValid: {}", value, isValid);
+        boolean isValid = fixedConsumptionQueryService.existsFixedConsumptionById(value);
+        log.info("ExistFixedConsumption consumptionRecordId: {}, isValid: {}", value, isValid);
 
         if(!isValid){
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.CONSUMPTION_RECORD_NOT_FOUND.toString()).addConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.FIXED_CONSUMPTION_NOT_FOUND.toString()).addConstraintViolation();
         }
 
         return isValid;


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #73 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 고정비 등록 -> `TotalConsumption` 테이블 생성
- 매월 1일 12시 고정비 등록 스케줄러 구현
  - 기존에 구현했던 예산, 총 소비 스케줄러를 삭제하고 고정비 등록 스케줄러로 통합
  -  매월 1일 00:00에 모든 사용자에 대해 고정비를 소비 기록(`ConsumptionRecord`) 으로 자동 등록
  - `Budget` 테이블 조회 또는 생성,`TotalConsumption` 테이블 조회 또는 생성, `ConsumptionCategory`(기본 타입) 테이블 조회 또는 생성, `isFixed` 컬럼이 true인 `ConsumptionRecord` 테이블 생성
- 고정비 수정
- 고정비 삭제
- 커서 기반 고정비 목록 조회 (기본 API 명세서에서 누락 되어서 새로 추가하여 구현)

빠른 시일 내에 배포 DB에도 관련 데이터들 채워 넣겠습니다.

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  구현하다보니 고정비와 예산은 관련이 없는 것 같아 고정비 `TotalConsumption` -  카테고리별 예산 `BudgetCategory` 연관관계를 삭제하고 `ConsumptionRecord`에 `isFixed` 필드를 추가하였습니다. i`sFixed`가 `true`인 경우는 고정비로, 매월 1일 12시에 소비 기록 `ConsumptionRecord` 테이블에 기록됩니다. (이번달에 등록하면 다음 달 소비 기록에 반영됨)
- `TotalConsumption` 과 `BudgetCategory` 의 연관관계를 끊었기 때문에, `TotalConsumption` 테이블의 외래키 목록에서 아래와 같이 `budget_category_id` 외래키를 삭제해주세요!
  <img width="553" height="169" alt="스크린샷 2025-07-25 오전 2 12 04" src="https://github.com/user-attachments/assets/e33c5680-b548-4522-b682-12fe8b0ef653" />
- 그리고 아래와 같이 DB 콘솔에서 명령어를 입력해서 관련 컬럼을 삭제해주세요. 소비 루틴 테이블의 설명 컬럼은, 지난 디자인에는 있었는데 다시 확인해보니 사라져서 수정했습니다. 마찬가지로 컬럼 드랍 부탁드립니다!
```
alter table fixed_consumption
    drop column budget_id;
```
```
alter table routine
    drop column routine_content;
```

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
- 고정비 등록 및 스케줄러
<img width="487" height="430" alt="스크린샷 2025-07-25 오전 1 56 14" src="https://github.com/user-attachments/assets/6cfa6670-583f-4353-bd90-b28d29462c15" />
<img width="1252" height="200" alt="스크린샷 2025-07-25 오전 12 30 57" src="https://github.com/user-attachments/assets/267e854f-b0c0-484f-b7a1-90658847dd1e" />  

&nbsp;
- 고정비 수정&삭제
<img width="469" height="150" alt="스크린샷 2025-07-25 오전 1 57 50" src="https://github.com/user-attachments/assets/9f9aa86f-2eaa-4fa9-a1e2-8ec45571d40f" />
<img width="713" height="444" alt="스크린샷 2025-07-25 오전 1 58 35" src="https://github.com/user-attachments/assets/bc6c2ea6-5add-4fcc-ab20-68168f364986" />

&nbsp;
- 커서 기반 고정비 목록 조회.
<img width="482" height="391" alt="스크린샷 2025-07-25 오전 1 55 09" src="https://github.com/user-attachments/assets/bb7ac044-eb6e-47b7-8cef-d695455f3a62" />. 

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
> 고정비 스케줄러에서 너무 많은 트랜잭션이 이루어지는 것 같은데, 유저가 많다면 부하가 많이 일어날 수 있을 것 같습니다.. 빠른 시일내에 적절한 방법을 찾아 리팩토링 하도록 하겠습니다.