### PR TITLE
[#75] 🐛Fix: 소비 카테고리 순서 고정되도록 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
@@ -140,8 +140,11 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
 
         // DEFAULT 타입일 경우만 유효성 검사 및 누락 보정 적용
         if (type == CategoryType.DEFAULT) {
+            // ✅ 기본 카테고리 순서 유지를 위해 LinkedHashMap 사용
+            Map<String, Integer> nameToAmount = new LinkedHashMap<>();
+
             // 요청된 이름-금액 쌍 추출
-            Map<String, Integer> nameToAmount = Optional.ofNullable(requestList).orElse(List.of()).stream()
+            Optional.ofNullable(requestList).orElse(List.of()).stream()
                     .filter(Objects::nonNull)
                     .map(dto -> {
                         if (dto instanceof BudgetRequest.DefaultCategoryBudget def)
@@ -149,31 +152,32 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
                         return null;
                     })
                     .filter(Objects::nonNull)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .forEach(entry -> nameToAmount.put(entry.getKey(), entry.getValue()));
 
-            // 예외 발생: 요청에 기본 카테고리 외의 이름이 포함된 경우
+            // ✅ 유효하지 않은 이름이 포함된 경우 예외 발생
             boolean hasInvalidName = nameToAmount.keySet().stream()
                     .anyMatch(name -> !DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.contains(name));
             if (hasInvalidName) {
                 throw new ErrorHandler(ErrorStatus.CONSUMPTION_CATEGORY_TYPE_NOT_FOUND);
             }
 
-            // 누락된 기본 카테고리 이름 중, 기존에 존재하지 않는 항목만 0원으로 보정
-            DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.stream()
-                    .filter(defaultName -> !nameToAmount.containsKey(defaultName)) // 요청에 없는 이름
-                    .filter(defaultName -> !existingMap.containsKey(defaultName)) // 기존에도 없는 이름
-                    .forEach(missing -> nameToAmount.put(missing, 0));
+            // ✅ 누락된 기본 카테고리 중 기존에도 없는 항목은 0원으로 보정 (순서 유지)
+            DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.forEach(name -> {
+                if (!nameToAmount.containsKey(name) && !existingMap.containsKey(name)) {
+                    nameToAmount.put(name, 0);
+                }
+            });
 
-            // 요청에 포함되었지만 이미 존재하는 항목은 제외
+            // ✅ 이미 존재하는 항목은 제거
             nameToAmount.keySet().removeIf(existingMap::containsKey);
 
-            // 실제 추가/갱신할 항목이 없는 경우 종료
+            // ✅ 실제 추가/갱신할 항목이 없는 경우 종료
             if (nameToAmount.isEmpty()) {
                 log.info("[카테고리 등록] 모든 기본 카테고리가 이미 존재하여 저장할 항목이 없습니다. userId={}, budgetId={}", user.getId(), budget.getId());
                 return;
             }
 
-            // 수정 공통 메서드 호출
+            // ✅ 공통 저장 로직 호출
             saveOrUpdateCategoryBudgetsByNameMap(nameToAmount, user, budget, type, existingMap);
         } else {
             // 그 외 타입은 기존 처리 방식 유지

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
@@ -17,6 +17,7 @@ import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.GeneralException;
+import com.server.money_touch.global.constants.DefaultCategoryConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -110,12 +111,22 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
 
         List<ConsumptionCategory> allCategories = consumptionCategoryRepository.findAllByUser(user);
 
+        // 순서 고정 리스트 사용
+        List<String> defaultOrder = DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES;
+
         return allCategories.stream()
                 .sorted(Comparator.comparingInt(cat -> {
                     CategoryType type = cat.getBudgetCategoryType();
-                    if (type == CategoryType.DEFAULT) return 0;
-                    if (type == CategoryType.CUSTOM) return 1;
-                    return 2; // ROUTINE_CATEGORY
+                    String name = cat.getBudgetCategoryName();
+
+                    if (type == CategoryType.DEFAULT) {
+                        int index = defaultOrder.indexOf(name);
+                        return index >= 0 ? index : Integer.MAX_VALUE;
+                    } else if (type == CategoryType.CUSTOM) {
+                        return 100; //
+                    } else {
+                        return 200; // ROUTINE_CATEGORY
+                    }
                 }))
                 .map(ConsumptionCategoryResponse.CategoryInfoDTO::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/com/server/money_touch/global/constants/DefaultCategoryConstants.java
+++ b/src/main/java/com/server/money_touch/global/constants/DefaultCategoryConstants.java
@@ -1,7 +1,8 @@
 package com.server.money_touch.global.constants;
 
-import java.util.Set;
+import java.util.List;
 
 public class DefaultCategoryConstants {
-    public static final Set<String> DEFAULT_CATEGORY_NAMES = Set.of("배달/외식", "패션/쇼핑", "교통", "카페", "기타");
+    // 순서 보장
+    public static final List<String> DEFAULT_CATEGORY_NAMES = List.of("배달/외식", "교통", "패션/쇼핑", "카페", "기타");
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #75 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 기본 타입의 `ConsumptionCategory` 테이블이 생길 때 "교통, 기타, 패션쇼핑, 배달/외식, 카페"에서 '배달/외식, 교통, 패션/쇼핑, 카페,기타" 순으로 생성되도록 수정
- 소비 카테고리 목록 조회 시 생성과 마찬가지로 기본 타입 카테고리 순서가 '배달/외식, 교통, 패션/쇼핑, 카페,기타" 순으로 조회되도록 수정

## 📌 공유 사항
X


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1045" height="206" alt="스크린샷 2025-07-29 오전 10 52 48" src="https://github.com/user-attachments/assets/b4312d77-4a6d-411f-8b33-de096cbf951b" />
<img width="526" height="466" alt="스크린샷 2025-07-29 오전 10 53 11" src="https://github.com/user-attachments/assets/16e5a8b9-50c9-416a-9104-b1e66e77b80c" />

## 💬 리뷰 요구사항 (선택)
> 지금은 생성, 조회 모두 순서가 고정되도록 수정했는데, 생각해보니 조회만 순서가 고정되도 큰 이슈는 없을 것 같긴 합니다. 그래도 편의성을 위해 생성도 순서가 고정되도록 하는게 좋을까요?
