### PR TITLE
[#80]Feat : SecurityConfig 코드 추가 및 소비루틴 기능 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -6,6 +6,8 @@ import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
 import com.server.money_touch.domain.budget.service.budget.BudgetQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +32,7 @@ public class BudgetController {
 
     private final BudgetCommandService budgetCommandService;
     private final BudgetQueryService budgetQueryService;
+    private final TokenProvider tokenProvider;
 
     // 가계부 한 달 예산 등록
     @Operation(
@@ -47,9 +51,16 @@ public class BudgetController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @PostMapping()
-    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(1L, request);
+    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
+                                                                        HttpServletRequest servletrequest) {
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
+
+        BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(userId, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
     Optional<Budget> findByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
+    Optional<Budget> findByUserIdAndCreatedMonth(Long userId, String createdMonth);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/ConsumptionRecordController.java
@@ -6,12 +6,15 @@ import com.server.money_touch.domain.consumptionRecord.dto.ConsumptionRecordResp
 import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecordService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.global.s3.S3Manager;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +35,7 @@ public class ConsumptionRecordController {
 
     private final ConsumptionRecordService consumptionRecordService;
     private final S3Manager s3Manager;
+    private final TokenProvider tokenProvider;
 
     // 소비 기록 등록
     @Operation(
@@ -49,7 +53,14 @@ public class ConsumptionRecordController {
     @PostMapping(value = "/record", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO> postConsumptionRecord(
             @RequestPart("data") @Valid ConsumptionRecordRequest.ConsumptionRecordCreateDTO request,
-            @RequestPart(value = "file", required = false) MultipartFile file){
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            HttpServletRequest servletrequest){
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
 
         try{
             // 이미지 업로드 처리 (dirName = "record")
@@ -60,7 +71,7 @@ public class ConsumptionRecordController {
 
             // 소비기록 저장 (이미지 URL 포함)
             ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response =
-                    consumptionRecordService.createConsumptionRecord(1L, request, imageUrl);
+                    consumptionRecordService.createConsumptionRecord(userId, request, imageUrl);
 
             return ApiResponse.onSuccess(response);
 
@@ -77,11 +88,16 @@ public class ConsumptionRecordController {
     @ApiSuccessCodeExample(resultClass = ConsumptionCategoryResponse.CategoryInfoDTO.class)
     @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND")
     @GetMapping("/categories")
-    public ApiResponse<List<ConsumptionCategoryResponse.CategoryInfoDTO>> getConsumptionCategories() {
+    public ApiResponse<List<ConsumptionCategoryResponse.CategoryInfoDTO>> getConsumptionCategories(HttpServletRequest servletrequest) {
 
-        // 유저 아이디 임시 지정
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
+
         List<ConsumptionCategoryResponse.CategoryInfoDTO> categoryList =
-                consumptionRecordService.getSortedCategoriesForUser(1L);
+                consumptionRecordService.getSortedCategoriesForUser(userId);
         return ApiResponse.onSuccess(categoryList);
     }
 

--- a/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
+++ b/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
@@ -7,10 +7,13 @@ import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.GeneralException;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -30,6 +33,7 @@ public class HomeController {
 
     private final HomeService homeService;
     private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
 
     @Operation(
             summary = "소비 통계 조회 API",
@@ -41,9 +45,15 @@ public class HomeController {
     })
 
     @GetMapping("/statistics")
-    public ApiResponse<HomeResponse.ConsumptionStatisticsTopResponseDTO> getTopStatistics(){
+    public ApiResponse<HomeResponse.ConsumptionStatisticsTopResponseDTO> getTopStatistics(HttpServletRequest servletrequest){
 
-        User user = userRepository.findById(1L)
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
+        User user = userRepository.findById(userId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return ApiResponse.onSuccess(homeService.getTopStatistics(user));
 
@@ -59,9 +69,15 @@ public class HomeController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @GetMapping("/statistics/others")
-    public ApiResponse<HomeResponse.OtherCategoryStatisticsResponseDTO> getOtherStatistics(){
+    public ApiResponse<HomeResponse.OtherCategoryStatisticsResponseDTO> getOtherStatistics(HttpServletRequest servletrequest){
 
-        User user = userRepository.findById(1L)
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
+        User user = userRepository.findById(userId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return ApiResponse.onSuccess(homeService.getOtherStatistics(user));
 
@@ -76,10 +92,16 @@ public class HomeController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @GetMapping("/ranking")
-    public ApiResponse<HomeResponse.WiseRankingResponseDTO> getWiseRanking() {
+    public ApiResponse<HomeResponse.WiseRankingResponseDTO> getWiseRanking(HttpServletRequest servletrequest) {
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
 
         // 임시 유저 지정
-        return ApiResponse.onSuccess(homeService.getWeeklyWiseRanking(1L));
+        return ApiResponse.onSuccess(homeService.getWeeklyWiseRanking(userId));
 
     }
 

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -7,6 +7,8 @@ import com.server.money_touch.domain.routine.service.RoutineCommandService;
 import com.server.money_touch.domain.routine.service.RoutineQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.global.s3.S3Manager;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,8 +25,6 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Tag(name = "가계부 소비 루틴 페이지", description = "가계부 소비 루틴에 관한 API")
 @Slf4j
@@ -36,6 +37,7 @@ public class RoutineController {
     private final RoutineCommandService routineCommandService;
     private final RoutineQueryService routineQueryService;
     private final S3Manager s3Manager;
+    private final TokenProvider tokenProvider;
 
     // 소비 루틴 등록
     @Operation(
@@ -57,9 +59,15 @@ public class RoutineController {
     })
     @PostMapping("/{budgetId}")
     public ApiResponse<RoutineResponse.RoutineCreateResultDTO> postRoutine(@Valid @RequestBody RoutineRequest.RoutineCreateDTO request,
-                                                                           @PathVariable Long budgetId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        RoutineResponse.RoutineCreateResultDTO response = routineCommandService.saveRoutineWithRoutineHashtags(1L, budgetId, request);
+                                                                           @PathVariable Long budgetId, HttpServletRequest servletrequest) {
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
+
+        RoutineResponse.RoutineCreateResultDTO response = routineCommandService.saveRoutineWithRoutineHashtags(userId, budgetId, request);
         return ApiResponse.onSuccess(response);
     }
 
@@ -81,36 +89,25 @@ public class RoutineController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 전체 소비 루틴 목록 조회
     @Operation(
-            summary = "전체 소비 루틴 리스트 조회 API",
-            description = "최신순으로 전체 소비 루틴을 조회합니다. 임시 더미데이터 입력한 상태입니다. "
-                    + "Try it out -> Execute 로 리스트 확인 가능합니다."
-                    + "당일 등록은 NEW 표시를 위해 true로 전달합니다.")
+            summary = "전체 소비 루틴 리스트 조회 API (커서 기반 무한스크롤)",
+            description = "최신순으로 전체 소비 루틴을 조회합니다. 당일 등록은 NEW 표시를 위해 true로 전달합니다.")
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
     })
+    @Parameter(name = "cursorId", description = "커서(이전 요청에서 마지막 소비 루틴 아이디), 첫번째 요청일 시에는 파라미터에 포함하지 않아도 됩니다.", example = "10", required = false)
+
     @GetMapping("/list")
-    public ApiResponse<List<RoutineResponse.RoutineListDTO>> getAllRoutines() {
+    public ApiResponse<RoutineResponse.AllRoutineListDTO> getAllRoutines(@RequestParam(required = false) Long cursorId) {
 
-        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
-        List<RoutineResponse.RoutineListDTO> routines = List.of(
-                new RoutineResponse.RoutineListDTO(
-                        1L, true, "2025-07-09", "50만원으로 한 달 살기 루틴",
-                        "라인", "https://", "https://",
-                        List.of("#식비절약", "#생활비")
-                ),
-
-                new RoutineResponse.RoutineListDTO(
-                        2L, false, "2025-06-10", "커피값을 아끼자",
-                        "오리", "https://", "https://",
-                        List.of("#카페지출줄이기", "#커피절약")
-                )
-        );
-        return ApiResponse.onSuccess(routines);
+        RoutineResponse.AllRoutineListDTO response = routineQueryService.getAllRoutineList(cursorId);
+        return ApiResponse.onSuccess(response);
     }
+
 
     // 내 소비 루틴 상세 조회
     @Operation(
@@ -155,6 +152,7 @@ public class RoutineController {
         }
     }
 
+    // 타인의 소비루틴 상세 조회
     @Operation(
             summary = "타인의 소비루틴 상세 조회 API",
             description = "전체 소비 루틴 리스트에서 소비 루틴 상세 정보를 조회하는 API입니다.")
@@ -168,11 +166,19 @@ public class RoutineController {
             @Parameter(name = "routineId", description = "조회하려는 소비 루틴 아이디", example = "1", required = true),
     })
     @GetMapping("/list/{routineId}")
-    public ApiResponse<RoutineResponse.RoutineListDetailDTO> getOtherDetailRoutine(@PathVariable Long routineId) {
-        RoutineResponse.RoutineListDetailDTO response = RoutineResponse.RoutineListDetailDTO.builder().build();
+    public ApiResponse<RoutineResponse.RoutineListDetailDTO> getOtherDetailRoutine(@PathVariable Long routineId, HttpServletRequest servletrequest) {
+
+        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
+        }
+        Long userId = tokenProvider.extractUserId(token);
+
+        RoutineResponse.RoutineListDetailDTO response = routineQueryService.getOtherRoutineDetail(userId, routineId);
         return ApiResponse.onSuccess(response);
     }
 
+    // 소비 루틴 예산 반영 전 수정/추가
     @Operation(
             summary = "소비 루틴 예산 반영 전 수정/추가 API",
             description = "내 예산에 반영-> 네 를 클릭하면 보여주는 api 입니다."+
@@ -195,6 +201,7 @@ public class RoutineController {
 
     }
 
+    // 소비 루틴 예산 반영
     @Operation(
             summary = "소비 루틴 예산 반영 API",
             description = "실제 예산에 반영. 새로운 카테고리는 ROUTINE_CATEGORY로 추가"
@@ -223,6 +230,7 @@ public class RoutineController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 소비 루틴 검색 (커서 기반 무한 스크롤)
     @Operation(
             summary = "소비 루틴 검색 API",
             description = "소비 루틴 제목으로 검색합니다."
@@ -234,26 +242,15 @@ public class RoutineController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @Parameters({
-            @Parameter(name = "keyword", description = "검색어 (루틴 이름)", example = "50만원", required = false)
+            @Parameter(name = "keyword", description = "검색어 (루틴 이름)", example = "50만원", required = false),
+            @Parameter(name = "cursorId", description = "커서(이전 요청에서 마지막 소비 루틴 아이디), 첫번째 요청일 시에는 파라미터에 포함하지 않아도 됩니다.", example = "10", required = false)
+
     })
     @GetMapping("/list/search")
-    public ApiResponse<List<RoutineResponse.RoutineListDTO>> searchRoutineList(
-            @RequestParam(required = false) String keyword) {
-
-        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
-        List<RoutineResponse.RoutineListDTO> response = List.of(
-                RoutineResponse.RoutineListDTO.builder()
-                        .routineId(1L)
-                        .isNew(true)
-                        .createDate("2025-07-11")
-                        .routineName("50만원으로 한 달 살기 루틴")
-                        .nickname("라인")
-                        .routineImgUrl("https://example.com/image.png")
-                        .profileImgUrl("https://example.com/profile.png")
-                        .hashtags(List.of("#절약", "#한달살기"))
-                        .build()
-        );
-
+    public ApiResponse<RoutineResponse.AllRoutineListDTO> searchRoutineList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long cursorId) {
+        RoutineResponse.AllRoutineListDTO response = routineQueryService.searchRoutineList(keyword, cursorId);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
@@ -17,7 +17,6 @@ public class RoutineConverter {
                 .budget(budget)
                 .routineName(routineCreateDTO.getRoutineName())
                 .routineImageUrl(routineCreateDTO.getRoutineImgUrl())
-                .viewCount(0)
                 .build();
     }
 
@@ -46,6 +45,18 @@ public class RoutineConverter {
     // 내 소비 루틴 목록 조회 응답 DTO
     public static RoutineResponse.MyRoutineListDTO toMyRoutineListDTO(List<RoutineResponse.RoutineThumbnailDTO> routineList, Slice<RoutineResponse.RoutineThumbnailDTO> slice) {
         return RoutineResponse.MyRoutineListDTO.builder()
+                .routineList(routineList)
+                .routineListSize(routineList.size())
+                .isFirst(slice.isFirst())
+                .isLast(slice.isLast())
+                .hasNext(slice.hasNext())
+                .nextCursorId(slice.hasNext() ? routineList.get(routineList.size() - 1).getRoutineId() : null)
+                .build();
+    }
+
+    // 전체 소비 루틴 목록 조회 응답 DTO
+    public static RoutineResponse.AllRoutineListDTO toAllRoutineListDTO(List<RoutineResponse.RoutineListDTO> routineList, Slice<RoutineResponse.RoutineListDTO> slice) {
+        return RoutineResponse.AllRoutineListDTO.builder()
                 .routineList(routineList)
                 .routineListSize(routineList.size())
                 .isFirst(slice.isFirst())

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -76,6 +76,35 @@ public class RoutineResponse {
     }
 
     @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "타인의 소비 루틴 정보")
+    public static class AllRoutineListDTO {
+
+        @Schema(description = "소비 루틴 목록")
+        List<RoutineListDTO> routineList;
+
+        @Schema(description = "현재 페이지의 소비 루틴 개수", example = "1")
+        Integer routineListSize;
+
+        @Schema(description = "페이지 처음 여부", example = "true")
+        Boolean isFirst;
+
+        @Schema(description = "페이지 마지막 여부", example = "false")
+        Boolean isLast;
+
+        @Schema(description = "다음 페이지가 있는지 여부", example = "true")
+        Boolean hasNext;
+
+        @Schema(description = "다음 요청에 사용할 커서 ID", example = "20")
+        private Long nextCursorId;
+    }
+
+
+    @Getter
+    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
@@ -179,6 +208,12 @@ public class RoutineResponse {
         ]
         """)
         private List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList;
+
+        @Schema(description = "내 예산에 반영 가능 여부", example = "true")
+        private boolean canApply;
+
+        @Schema(description = "반영 불가 메시지", example = "소비루틴은 한 달에 한 번만 반영할 수 있어요")
+        private String cannotApplyMessage;
     }
 
     @Getter

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -18,9 +18,6 @@ public class Routine extends BaseEntity {
     @Column(nullable = false)
     private String routineImageUrl;
 
-    @Column(columnDefinition = "INT DEFAULT 0", nullable = false)
-    private Integer viewCount; // 조회수
-
     // 소비루틴-예산 다대일
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "budget_id")

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryCustom.java
@@ -7,4 +7,10 @@ import org.springframework.data.domain.Slice;
 public interface RoutineRepositoryCustom {
     // 사용자의 소비 루틴 목록을 커서 기반으로 조회하고, 각 루틴에 연결된 해시태그를 함께 반환
     Slice<RoutineResponse.RoutineThumbnailDTO> findUserRoutineList(Long userId, Long cursorId, Pageable pageable);
+
+    // 전체 소비 루틴 목록을 커서 기반으로 조회, 연결된 해시태그 반환
+    Slice<RoutineResponse.RoutineListDTO> findAllRoutines(Long cursorId, Pageable pageable);
+
+    // 검색어로 소비루틴 반환
+    Slice<RoutineResponse.RoutineListDTO> searchRoutinesByKeyword(String keyword, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -79,6 +80,107 @@ public class RoutineRepositoryImpl implements RoutineRepositoryCustom {
             r.setHashtags(hashtags);
         });
 
+        return new SliceImpl<>(routines, pageable, hasNext);
+    }
+
+    // 전체 소비 루틴을 커서 기반 무한스크롤로 반환, 연결된 해시태그도 함께 반환
+    @Override
+    public Slice<RoutineResponse.RoutineListDTO> findAllRoutines(Long cursorId, Pageable pageable) {
+        LocalDate today = LocalDate.now();
+
+        // 루틴 정보 조회
+        List<RoutineResponse.RoutineListDTO> routines = queryFactory
+                .select(Projections.fields(RoutineResponse.RoutineListDTO.class,
+                        routine.id.as("routineId"),
+                        routine.createdAt.stringValue().substring(0,10).as("createDate"), // yyyy-MM-dd
+                        routine.routineName,
+                        user.nickname,
+                        routine.routineImageUrl.as("routineImgUrl"),
+                        user.profileImgUrl.as("profileImgUrl")
+                ))
+                .from(routine)
+                .join(routine.user, user)
+                .where(cursorId != null ? routine.id.lt(cursorId) : null)
+                .orderBy(routine.createdAt.desc(), routine.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        // 다음 페이지 여부
+        boolean hasNext = routines.size() > pageable.getPageSize();
+        if (hasNext) routines.remove(pageable.getPageSize());
+
+        // 루틴 ID 리스트
+        List<Long> routineIds = routines.stream()
+                .map(RoutineResponse.RoutineListDTO::getRoutineId)
+                .toList();
+
+        if (!routineIds.isEmpty()) {
+            // 해시태그 조회
+            Map<Long, List<String>> hashtagMap = queryFactory
+                    .select(routineHashtag.routine.id, routineHashtag.routineHashtagName)
+                    .from(routineHashtag)
+                    .where(routineHashtag.routine.id.in(routineIds))
+                    .fetch()
+                    .stream()
+                    .collect(Collectors.groupingBy(
+                            tuple -> tuple.get(routineHashtag.routine.id),
+                            Collectors.mapping(tuple -> tuple.get(routineHashtag.routineHashtagName), Collectors.toList())
+                    ));
+
+            // 해시태그 & NEW 여부 설정
+            routines.forEach(r -> {
+                r.setHashtags(hashtagMap.getOrDefault(r.getRoutineId(), List.of()));
+                r.setNew(LocalDate.parse(r.getCreateDate()).isEqual(today));
+            });
+        }
+
+        return new SliceImpl<>(routines, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<RoutineResponse.RoutineListDTO> searchRoutinesByKeyword(String keyword, Long cursorId, Pageable pageable) {
+        LocalDate today = LocalDate.now();
+
+        List<RoutineResponse.RoutineListDTO> routines = queryFactory
+                .select(Projections.fields(RoutineResponse.RoutineListDTO.class,
+                        routine.id.as("routineId"),
+                        routine.createdAt.stringValue().substring(0,10).as("createDate"),
+                        routine.routineName,
+                        user.nickname,
+                        routine.routineImageUrl.as("routineImgUrl"),
+                        user.profileImgUrl.as("profileImgUrl")
+                ))
+                .from(routine)
+                .join(routine.user, user)
+                .where(
+                        (keyword != null ? routine.routineName.containsIgnoreCase(keyword) : null),
+                        (cursorId != null ? routine.id.lt(cursorId) : null)
+                )
+                .orderBy(routine.createdAt.desc(), routine.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = routines.size() > pageable.getPageSize();
+        if (hasNext) routines.remove(pageable.getPageSize());
+
+        // 해시태그 조회
+        List<Long> routineIds = routines.stream().map(RoutineResponse.RoutineListDTO::getRoutineId).toList();
+        if (!routineIds.isEmpty()) {
+            Map<Long, List<String>> hashtagMap = queryFactory
+                    .select(routineHashtag.routine.id, routineHashtag.routineHashtagName)
+                    .from(routineHashtag)
+                    .where(routineHashtag.routine.id.in(routineIds))
+                    .fetch()
+                    .stream()
+                    .collect(Collectors.groupingBy(
+                            tuple -> tuple.get(routineHashtag.routine.id),
+                            Collectors.mapping(tuple -> tuple.get(routineHashtag.routineHashtagName), Collectors.toList())
+                    ));
+            routines.forEach(r -> {
+                r.setHashtags(hashtagMap.getOrDefault(r.getRoutineId(), List.of()));
+                r.setNew(LocalDate.parse(r.getCreateDate()).isEqual(today));
+            });
+        }
         return new SliceImpl<>(routines, pageable, hasNext);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
@@ -13,4 +13,13 @@ public interface RoutineQueryService {
 
     // 내 소비 루틴 목록 조회 (커서 기반 무한스크롤)
     RoutineResponse.MyRoutineListDTO getMyRoutineList(@ExistUser Long userId, Long cursorId);
+
+    // 전체 소비 루틴 목록 조회 (커서 기반 무한스크롤)
+    RoutineResponse.AllRoutineListDTO getAllRoutineList(Long cursorId);
+
+    // 소비 루틴 상세 조회
+    RoutineResponse.RoutineListDetailDTO getOtherRoutineDetail(@ExistUser Long userId, @ExistRoutine Long routineId);
+
+    // 검색 키워드로 소비 루틴 목록 조회(커서 기반 무한스크롤)
+    RoutineResponse.AllRoutineListDTO searchRoutineList(String keyword, Long cursorId);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.server.money_touch.domain.routine.service;
 import com.server.money_touch.domain.budget.entity.Budget;
 import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
 import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
 import com.server.money_touch.domain.routine.converter.RoutineConverter;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -36,6 +38,7 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
     private final RoutineRepository routineRepository;
     private final UserRepository userRepository;
     private final BudgetCategoryRepository budgetCategoryRepository;
+    private final BudgetRepository budgetRepository;
 
     // 소비 루틴 존재 여부 검증
     @Override
@@ -94,5 +97,65 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
 
         log.info("내 소비 루틴 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, cursorId: {}", userId, cursorId);
         return RoutineConverter.toMyRoutineListDTO(routineList, slice);
+    }
+
+    @Override
+    public RoutineResponse.AllRoutineListDTO getAllRoutineList(Long cursorId) {
+
+        // 페이지 크기 10, 0페이지부터 시작
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+
+        // Repository 호출 → 커서 기반 + 해시태그 + NEW 여부
+        Slice<RoutineResponse.RoutineListDTO> slice = routineRepository.findAllRoutines(cursorId, pageable);
+
+        // 조회한 루틴 리스트 추출
+        List<RoutineResponse.RoutineListDTO> routineList = slice.getContent();
+
+        log.info("전체 소비 루틴 목록 조회(커서 기반 무한스크롤) 완료 - cursorId: {}", cursorId);
+        return RoutineConverter.toAllRoutineListDTO(routineList, slice);
+    }
+
+    // 타인 소비 루틴 상세 조회
+    @Override
+    public RoutineResponse.RoutineListDetailDTO getOtherRoutineDetail(Long userId, Long routineId) {
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        Budget routineBudget = routine.getBudget();
+        List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllWithCategoryByBudgetId(routineBudget.getId());
+
+        // 금액이 0원인 카테고리 제외
+        List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = budgetCategories.stream()
+                .filter(bc -> bc.getBudgetCategoryMoney() != null && bc.getBudgetCategoryMoney() > 0)
+                .map(bc -> RoutineResponse.CategoryBudgetDetailDTO.builder()
+                        .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
+                        .amount(bc.getBudgetCategoryMoney())
+                        .build())
+                .toList();
+
+        String createdMonth = LocalDate.now().withDayOfMonth(1).toString().substring(0, 7);
+        Optional<Budget> myBudgetOpt = budgetRepository.findByUserIdAndCreatedMonth(userId, createdMonth);
+
+        boolean canApply = true;
+        String message = null;
+        if (myBudgetOpt.isPresent() && Boolean.TRUE.equals(myBudgetOpt.get().getIsFromRoutine())) {
+            canApply = false;
+            message = "소비루틴은 한 달에 한 번만 반영할 수 있어요";
+        }
+
+        return RoutineResponse.RoutineListDetailDTO.builder()
+                .totalBudget(routineBudget.getBudgetTotal())
+                .routineName(routine.getRoutineName())
+                .categoryBudgetList(categoryBudgetList)
+                .canApply(canApply)
+                .cannotApplyMessage(message)
+                .build();
+    }
+
+    @Override
+    public RoutineResponse.AllRoutineListDTO searchRoutineList(String keyword, Long cursorId) {
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+        Slice<RoutineResponse.RoutineListDTO> slice = routineRepository.searchRoutinesByKeyword(keyword, cursorId, pageable);
+        return RoutineConverter.toAllRoutineListDTO(slice.getContent(), slice);
     }
 }

--- a/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.server.money_touch.global.config;
 
+import com.server.money_touch.global.config.jwt.JwtAuthenticationFilter;
+import com.server.money_touch.global.config.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,10 +11,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,7 +36,8 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자 페이지 접근 제어
                         .anyRequest().authenticated() // 나머지는 인증 필요
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 //                .formLogin((form) -> form
 //                        .loginPage("/login")
 //                        .defaultSuccessUrl("/home", true)
@@ -47,5 +55,10 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(tokenProvider);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #80 

## 📝 작업 내용

- SecurityConfig 에 JwtAuthenticationFilter 가 등록되어 있지 않은 것 같아 추가했습니다.
- 만약 필요 없는 코드라면 알려주세요!

<img width="2191" height="1246" alt="스크린샷 2025-07-30 143709" src="https://github.com/user-attachments/assets/dbb982fb-8a6f-4271-b9a7-948cbf34105d" />
<img width="1075" height="199" alt="스크린샷 2025-07-30 143700" src="https://github.com/user-attachments/assets/a8839fbb-507b-4ae5-92df-6f1677a63ba3" />


- 소비루틴 관련 기능 구현 : 전체 소비 루틴 리스트 조회, 타인의 소비루틴 상세 조회, 소비루틴 검색
-> 소비루틴을 조회순으로 보여주지 않는다고 하여 entity 에서 viewCount 삭제

1. 전체 소비루틴 리스트 조회
<img width="1851" height="680" alt="스크린샷 2025-07-30 144203" src="https://github.com/user-attachments/assets/9e07df7d-29f7-45aa-ae14-ec27b9902d79" />

2. 타인의 소비루틴 상세 조회
<img width="1853" height="1314" alt="스크린샷 2025-07-30 144337" src="https://github.com/user-attachments/assets/642beac9-6a97-4acf-87ab-c5fbd5e04fb2" />

3. 소비루틴 검색
<img width="1860" height="598" alt="스크린샷 2025-07-30 144410" src="https://github.com/user-attachments/assets/6c9fc0a6-ddff-4fbf-ba0a-52ff0b79b46c" />


## 📌 공유 사항

-  저는 컨트롤러에 jwt 적용을 이렇게 했습니다! 혹시 더 간단한 코드가 있다면 알려주세요
`private final TokenProvider tokenProvider;`
-> 컨트롤러에 위 코드 추가 후 userId 가 필요한 api 에 코드 추가
<img width="2183" height="852" alt="스크린샷 2025-07-30 143636" src="https://github.com/user-attachments/assets/fdd9a0a1-2465-471a-9876-f63440ebd89d" />

`HttpServletRequest servletrequest`
```
String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
        if (token == null) {
            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
        }
Long userId = tokenProvider.extractUserId(token);
```
-> 1L 이라고 지정했던 부분을 userId로 수정

- 테스트 때문에 미정님 담당기능 중 예산 등록, 소비루틴 등록은 jwt 를 받도록 코드를 변경했습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?
