### PR TITLE
[#79] Refactor: 알림 관련 기능 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/server/money_touch/domain/notification/converter/NotificationConverter.java
@@ -15,15 +15,22 @@ public class NotificationConverter {
             return null;
         }
 
+        // 게시글 기반 알림 타입이면 imageUrl 포함
+        String typeName = notification.getNotificationType().getNotificationTypeName();
+        boolean isPostRelated = typeName.equals("COMMENT")
+                || typeName.equals("WISE")
+                || typeName.equals("WASTE");
+
         return NotificationResponse.NotificationDetailDTO.builder()
                 .notificationId(notification.getId())
                 .title(notification.getTitle())
                 .content(notification.getContent())
                 .notificationTypeName(notification.getNotificationType().getNotificationTypeName())
                 .imgUrl(notification.getNotificationType().getImgUrl())
-                .senderId(notification.getSenderId())
+                .senderName(notification.getSenderName())
                 .targetId(notification.getTargetId())
                 .isRead(notification.getIsRead())
+                .imageUrl(isPostRelated ? notification.getImageUrl() : null)
                 .createdAt(notification.getCreatedAt())
                 .build();
 

--- a/src/main/java/com/server/money_touch/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/server/money_touch/domain/notification/dto/NotificationResponse.java
@@ -58,14 +58,17 @@ public class NotificationResponse {
         @Schema(description = "알림 유형 이미지 URL", example = "http://example.com/comment.png")
         private String imgUrl;
 
-        @Schema(description = "발신자 아이디", example = "2")
-        private Long senderId;
+        @Schema(description = "발신자 이름", example = "제이")
+        private String senderName;
 
         @Schema(description = "대상 아이디", example = "10")
         private Long targetId;
 
         @Schema(description = "읽음 여부", example = "false")
         private Boolean isRead;
+
+        @Schema(description = "소비기록 대표 이미지 URL", example = "http://image.com/comment.png")
+        private String imageUrl;
 
         @Schema(description = "알림 생성 일시", example = "2025-01-15T14:30:25")
         private LocalDateTime createdAt;

--- a/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
+++ b/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
@@ -30,7 +30,7 @@ public class Notification extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String title;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 70)
     private String content;
 
     private Boolean isRead = false;

--- a/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
+++ b/src/main/java/com/server/money_touch/domain/notification/entity/Notification.java
@@ -24,9 +24,8 @@ public class Notification extends BaseEntity {
     @JoinColumn(name = "notification_type_id", nullable = false)
     private NotificationType notificationType;
 
-    // 알림 발신자
-    @Column(nullable = false)
-    private Long senderId;
+    // 알림 발신자 이름
+    private String senderName;
 
     @Column(nullable = false, length = 20)
     private String title;
@@ -38,6 +37,9 @@ public class Notification extends BaseEntity {
 
     @Column(nullable = false)
     private Long targetId;
+
+    // 게시글에 관한 알림일 경우 게시글 사진
+    private String imageUrl;
 
     // 읽음 처리
     public void markAsRead() {


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #79 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 해당 알림이 게시글에 대한 알림일 경우 게시글의 이미지를 보여줘야 하므로 이미지 url 컬럼 추가
- 알림 내용 길이 50 -> 70으로 수정
- 해당 알림의 발신자 id -> 발신자 명으로 변경
- 알림은 더미데이터로 채우기때문에 게시글과 연결하지 않고 이미지 url 컬럼을 직접 추가하였습니다.

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
