### PR TITLE
[#83]Feat: jwt 공통 메서드 생성, 소비루틴 최신순 5개 리스트 반환 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -8,6 +8,7 @@ import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.global.config.jwt.TokenProvider;
+import com.server.money_touch.global.utils.AuthUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -32,7 +33,7 @@ public class BudgetController {
 
     private final BudgetCommandService budgetCommandService;
     private final BudgetQueryService budgetQueryService;
-    private final TokenProvider tokenProvider;
+    private final AuthUtil authUtil;
 
     // 가계부 한 달 예산 등록
     @Operation(
@@ -54,11 +55,7 @@ public class BudgetController {
     public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
                                                                         HttpServletRequest servletrequest) {
 
-        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
-        if (token == null) {
-            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
-        }
-        Long userId = tokenProvider.extractUserId(token);
+        Long userId = authUtil.getUserIdFromRequest(servletrequest);
 
         BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(userId, request);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
+++ b/src/main/java/com/server/money_touch/domain/home/controller/HomeController.java
@@ -9,6 +9,7 @@ import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.GeneralException;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.global.config.jwt.TokenProvider;
+import com.server.money_touch.global.utils.AuthUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,7 +34,7 @@ public class HomeController {
 
     private final HomeService homeService;
     private final UserRepository userRepository;
-    private final TokenProvider tokenProvider;
+    private final AuthUtil authUtil;
 
     @Operation(
             summary = "소비 통계 조회 API",
@@ -47,12 +48,7 @@ public class HomeController {
     @GetMapping("/statistics")
     public ApiResponse<HomeResponse.ConsumptionStatisticsTopResponseDTO> getTopStatistics(HttpServletRequest servletrequest){
 
-
-        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
-        if (token == null) {
-            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
-        }
-        Long userId = tokenProvider.extractUserId(token);
+        Long userId = authUtil.getUserIdFromRequest(servletrequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return ApiResponse.onSuccess(homeService.getTopStatistics(user));
@@ -72,11 +68,7 @@ public class HomeController {
     public ApiResponse<HomeResponse.OtherCategoryStatisticsResponseDTO> getOtherStatistics(HttpServletRequest servletrequest){
 
 
-        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
-        if (token == null) {
-            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
-        }
-        Long userId = tokenProvider.extractUserId(token);
+        Long userId = authUtil.getUserIdFromRequest(servletrequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return ApiResponse.onSuccess(homeService.getOtherStatistics(user));
@@ -94,22 +86,16 @@ public class HomeController {
     @GetMapping("/ranking")
     public ApiResponse<HomeResponse.WiseRankingResponseDTO> getWiseRanking(HttpServletRequest servletrequest) {
 
-        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
-        if (token == null) {
-            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
-        }
-        Long userId = tokenProvider.extractUserId(token);
+        Long userId = authUtil.getUserIdFromRequest(servletrequest);
 
-        // 임시 유저 지정
         return ApiResponse.onSuccess(homeService.getWeeklyWiseRanking(userId));
 
     }
 
     @Operation(
             summary = "소비 루틴 목록 5개 조회 API",
-            description = "사용자들이 등록한 소비 루틴들을 조회순 5개 보여줍니다.당일 등록된 루틴은 NEW 표시가 추가됩니다."+
-            "Try it out -> Execute 로 리스트 확인 가능합니다. " +
-            "임시 더미데이터 입력한 상태")
+            description = "사용자들이 등록한 소비 루틴들을 최신순으로 5개 보여줍니다.당일 등록된 루틴은 NEW 표시가 추가됩니다."+
+                        "낮 12시마다 갱신됩니다.")
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
@@ -118,37 +104,7 @@ public class HomeController {
     })
     @GetMapping("/routinesPreview")
     public ApiResponse<List<HomeResponse.RoutinePreviewDTO>> getRoutinePreviews() {
-
-        // TODO: 실제 데이터로 교체 예정. 임시 더미데이터
-        List<HomeResponse.RoutinePreviewDTO> routines = List.of(
-                new HomeResponse.RoutinePreviewDTO(
-                        1L, "https://",
-                        "50만원으로 한 달 살기 루틴",
-                        true
-                ),
-                new HomeResponse.RoutinePreviewDTO(
-                        2L,"https://",
-                        "배달 끊고 집밥 먹기 예산",
-                         true
-                ),
-                new HomeResponse.RoutinePreviewDTO(
-                        3L, "https://",
-                        "커피값을 아끼자",
-                        false
-                ),
-                new HomeResponse.RoutinePreviewDTO(
-                        4L, "https://",
-                        "쇼핑은 10만원만",
-                        false
-                ),
-                new HomeResponse.RoutinePreviewDTO(
-                        5L, "https://",
-                        "줄줄 새는 고정비 확인하기",
-                        false
-                )
-        );
-
-        return ApiResponse.onSuccess(routines);
+        return ApiResponse.onSuccess(homeService.getRoutinePreviewList());
     }
 
     @Operation(
@@ -158,6 +114,16 @@ public class HomeController {
     public ApiResponse<String> refreshWiseRankingManually() {
         homeService.calculateAndSaveWeeklyWiseRanking();
         return ApiResponse.onSuccess("주간 랭킹 수동 갱신 완료");
+    }
+
+    @Operation(
+            summary = "[관리자용] 소비 루틴 미리보기 캐시 수동 갱신 API",
+            description = "소비 루틴 미리보기 캐시를 강제로 갱신합니다. (매일 12시 스케줄 실행 전에도 사용 가능)"
+    )
+    @GetMapping("/routinesPreview/refresh")
+    public ApiResponse<String> refreshRoutinePreviewManually() {
+        homeService.refreshRoutinePreviewCache();
+        return ApiResponse.onSuccess("소비 루틴 미리보기 캐시 수동 갱신 완료");
     }
 
 }

--- a/src/main/java/com/server/money_touch/domain/home/dto/HomeResponse.java
+++ b/src/main/java/com/server/money_touch/domain/home/dto/HomeResponse.java
@@ -96,14 +96,11 @@ public class HomeResponse {
 
     @Getter
     @AllArgsConstructor
-    @Schema(description = "소비 루틴 조회순 5개")
+    @Schema(description = "소비 루틴 최신순 5개")
     public static class RoutinePreviewDTO {
 
         @Schema(description = "소비 루틴 id", example = "1")
         private Long routineId;
-
-        @Schema(description = "아이콘 이미지", example = "https://")
-        private String iconImgUrl;
 
         @Schema(description = "루틴 이름", example = "50만원으로 한 달 살기 루틴")
         private String routineName;
@@ -111,6 +108,5 @@ public class HomeResponse {
         @Schema(description = "당일 등록 여부", example = "true")
         private boolean isNew;
     }
-
 
 }

--- a/src/main/java/com/server/money_touch/domain/home/service/HomeService.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/HomeService.java
@@ -3,13 +3,24 @@ package com.server.money_touch.domain.home.service;
 import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.user.entity.User;
 
+import java.util.List;
+
 public interface HomeService {
 
+    // 소비왕 랭킹 조회
     HomeResponse.WiseRankingResponseDTO getWeeklyWiseRanking(Long userId);
 
+    // 소비왕 계산, 저장
     void calculateAndSaveWeeklyWiseRanking();
 
+    // 소비 통계(전체)
     HomeResponse.ConsumptionStatisticsTopResponseDTO getTopStatistics(User user);
 
+    // 소비 통계(그외 카테고리)
     HomeResponse.OtherCategoryStatisticsResponseDTO getOtherStatistics(User user);
+
+    // 소비루틴 최신순으로 5개만 반환
+    List<HomeResponse.RoutinePreviewDTO> getRoutinePreviewList();
+
+    void refreshRoutinePreviewCache();
 }

--- a/src/main/java/com/server/money_touch/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/HomeServiceImpl.java
@@ -5,11 +5,13 @@ import com.server.money_touch.domain.consumptionRecord.repository.consumptionRec
 import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.home.entity.WiseRankingHistory;
 import com.server.money_touch.domain.home.repository.WiseRankingHistoryRepository;
+import com.server.money_touch.domain.routine.repository.routine.RoutineRepository;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HomeServiceImpl implements HomeService {
@@ -25,6 +28,8 @@ public class HomeServiceImpl implements HomeService {
     private final UserRepository userRepository;
     private final ConsumptionRecordRepository consumptionRecordRepository;
     private final WiseRankingHistoryRepository wiseRankingHistoryRepository;
+    private final RoutineRepository routineRepository;
+    private List<HomeResponse.RoutinePreviewDTO> cachedRoutinePreviews = new ArrayList<>();
 
     @Override
     @Transactional
@@ -255,6 +260,19 @@ public class HomeServiceImpl implements HomeService {
         }
 
         return new HomeResponse.OtherCategoryStatisticsResponseDTO(othersList);
+    }
+
+    /** 스케줄러에서 호출: 최신 5개 DB조회 → 캐싱 */
+    public void refreshRoutinePreviewCache() {
+        cachedRoutinePreviews = routineRepository.findTop5LatestRoutines();
+        log.info("소비 루틴 최신 5개 캐시 갱신 완료, size={}", cachedRoutinePreviews.size());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<HomeResponse.RoutinePreviewDTO> getRoutinePreviewList() {
+        // DB 직접 조회 대신 캐시 반환
+        return cachedRoutinePreviews;
     }
 }
 

--- a/src/main/java/com/server/money_touch/domain/home/service/RoutineSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/home/service/RoutineSchedulerService.java
@@ -1,0 +1,21 @@
+package com.server.money_touch.domain.home.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RoutineSchedulerService {
+
+    private final HomeService homeService;
+
+    /** 매일 낮 12시에 캐시 갱신 */
+    @Scheduled(cron = "0 0 12 * * ?")
+    public void refreshRoutinePreviewCache() {
+        homeService.refreshRoutinePreviewCache();
+        log.info("정기 스케줄러 실행 -> 소비 루틴 미리보기 데이터 캐시 갱신 완료");
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -10,6 +10,7 @@ import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.global.s3.S3Manager;
+import com.server.money_touch.global.utils.AuthUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -37,7 +38,7 @@ public class RoutineController {
     private final RoutineCommandService routineCommandService;
     private final RoutineQueryService routineQueryService;
     private final S3Manager s3Manager;
-    private final TokenProvider tokenProvider;
+    private final AuthUtil authUtil;
 
     // 소비 루틴 등록
     @Operation(
@@ -61,11 +62,7 @@ public class RoutineController {
     public ApiResponse<RoutineResponse.RoutineCreateResultDTO> postRoutine(@Valid @RequestBody RoutineRequest.RoutineCreateDTO request,
                                                                            @PathVariable Long budgetId, HttpServletRequest servletrequest) {
 
-        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
-        if (token == null) {
-            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
-        }
-        Long userId = tokenProvider.extractUserId(token);
+        Long userId = authUtil.getUserIdFromRequest(servletrequest);
 
         RoutineResponse.RoutineCreateResultDTO response = routineCommandService.saveRoutineWithRoutineHashtags(userId, budgetId, request);
         return ApiResponse.onSuccess(response);
@@ -168,11 +165,7 @@ public class RoutineController {
     @GetMapping("/list/{routineId}")
     public ApiResponse<RoutineResponse.RoutineListDetailDTO> getOtherDetailRoutine(@PathVariable Long routineId, HttpServletRequest servletrequest) {
 
-        String token = TokenProvider.resolveToken(servletrequest);  // Authorization 헤더에서 토큰 추출
-        if (token == null) {
-            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // or 인증 실패 예외
-        }
-        Long userId = tokenProvider.extractUserId(token);
+        Long userId = authUtil.getUserIdFromRequest(servletrequest);
 
         RoutineResponse.RoutineListDetailDTO response = routineQueryService.getOtherRoutineDetail(userId, routineId);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.server.money_touch.domain.routine.repository.routine;
 
+import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 public interface RoutineRepositoryCustom {
     // 사용자의 소비 루틴 목록을 커서 기반으로 조회하고, 각 루틴에 연결된 해시태그를 함께 반환
@@ -13,4 +16,7 @@ public interface RoutineRepositoryCustom {
 
     // 검색어로 소비루틴 반환
     Slice<RoutineResponse.RoutineListDTO> searchRoutinesByKeyword(String keyword, Long cursorId, Pageable pageable);
+
+    // 최신순으로 5개만 반환
+    List<HomeResponse.RoutinePreviewDTO> findTop5LatestRoutines();
 }

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.server.money_touch.domain.routine.repository.routine;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.domain.routine.entity.QRoutine;
 import com.server.money_touch.domain.routine.entity.QRoutineHashtag;
@@ -182,5 +183,23 @@ public class RoutineRepositoryImpl implements RoutineRepositoryCustom {
             });
         }
         return new SliceImpl<>(routines, pageable, hasNext);
+    }
+
+    @Override
+    public List<HomeResponse.RoutinePreviewDTO> findTop5LatestRoutines() {
+        LocalDate today = LocalDate.now();
+
+        List<HomeResponse.RoutinePreviewDTO> routines = queryFactory
+                .select(Projections.constructor(HomeResponse.RoutinePreviewDTO.class,
+                        routine.id,
+                        routine.routineName,
+                        routine.createdAt.stringValue().substring(0,10).eq(today.toString()) // 당일 등록 여부 체크
+                ))
+                .from(routine)
+                .orderBy(routine.createdAt.desc(), routine.id.desc())
+                .limit(5)
+                .fetch();
+
+        return routines;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
@@ -1,8 +1,11 @@
 package com.server.money_touch.domain.routine.service;
 
+import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.global.validation.annotation.ExistRoutine;
 import com.server.money_touch.global.validation.annotation.ExistUser;
+
+import java.util.List;
 
 public interface RoutineQueryService {
     // 소비 루틴 존재 여부 검증

--- a/src/main/java/com/server/money_touch/global/utils/AuthUtil.java
+++ b/src/main/java/com/server/money_touch/global/utils/AuthUtil.java
@@ -1,0 +1,23 @@
+package com.server.money_touch.global.utils;
+
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.config.jwt.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUtil {
+
+    private final TokenProvider tokenProvider;
+
+    public Long getUserIdFromRequest(HttpServletRequest request) {
+        String token = TokenProvider.resolveToken(request);  // Authorization 헤더에서 토큰 추출
+        if (token == null) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);  // 인증 실패 예외
+        }
+        return tokenProvider.extractUserId(token);
+    }
+}


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> #83 

## 📝 작업 내용

- 이전 pr에서 생성했던 jwt 추출 코드를 따로 global-> utils 폴더에 AuthUtil 로 공통 메서드를 만들었습니다. 
- 홈 화면에서 소비루틴을 최신순으로 5개 보여주는 기능을 구현했습니다.
-> 매일 낮 12시마다 갱신되고, 캐시로 저장하는데 로컬로는 내일 낮에 다시 테스트해볼 예정입니다.

## 📌 공유 사항

-  jwt 추출 공통 메서드 적용 방법
<img width="1132" height="288" alt="image" src="https://github.com/user-attachments/assets/c2812d90-13a1-4da7-b784-be1fab41de02" />
<img width="1494" height="367" alt="image" src="https://github.com/user-attachments/assets/031c4356-f87a-4cd1-ac34-ee489410164b" />

컨트롤러에 아래 코드 추가
`private final AuthUtil authUtil;`

userId 가 필요한 api 내에 아래 코드 추가

`Long userId = authUtil.getUserIdFromRequest(servletrequest);`


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

