### PR TITLE
[#90] Fix: 가계부 JWT 기반 인증으로 변경 및 토큰 생성 시 nickname -> email 정보로 변경

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -53,9 +53,10 @@ public class BudgetController {
     })
     @PostMapping()
     public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
-                                                                        HttpServletRequest servletrequest) {
+                                                                        HttpServletRequest servletRequest) {
 
-        Long userId = authUtil.getUserIdFromRequest(servletrequest);
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        log.info("userId, {}", userId);
 
         BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(userId, request);
         return ApiResponse.onSuccess(response);
@@ -76,9 +77,9 @@ public class BudgetController {
             @Parameter(name = "budgetId", description = "조회하려는 예산 아이디", example = "1", required = true),
     })
     @GetMapping("/{budgetId}")
-    public ApiResponse<BudgetResponse.BudgetDetailDTO> getBudget(@PathVariable Long budgetId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        BudgetResponse.BudgetDetailDTO response = budgetQueryService.findBudgetById(1L, budgetId);
+    public ApiResponse<BudgetResponse.BudgetDetailDTO> getBudget(@PathVariable Long budgetId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        BudgetResponse.BudgetDetailDTO response = budgetQueryService.findBudgetById(userId, budgetId);
         return ApiResponse.onSuccess(response);
     }
 
@@ -100,9 +101,9 @@ public class BudgetController {
             @Parameter(name = "month", description = "조회하려는 월", example = "7", required = true),
     })
     @GetMapping("/total-consumption")
-    public ApiResponse<BudgetResponse.TotalConsumptionResultDTO> getTotalConsumption(@RequestParam Integer year, @RequestParam Integer month) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        BudgetResponse.TotalConsumptionResultDTO response = budgetQueryService.findBudgetByIdAndTotalConsumption(1L, year, month);
+    public ApiResponse<BudgetResponse.TotalConsumptionResultDTO> getTotalConsumption(@RequestParam Integer year, @RequestParam Integer month, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        BudgetResponse.TotalConsumptionResultDTO response = budgetQueryService.findBudgetByIdAndTotalConsumption(userId, year, month);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/HouseholdConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/HouseholdConsumptionController.java
@@ -5,6 +5,7 @@ import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecord
 import com.server.money_touch.domain.consumptionRecord.service.ConsumptionRecordQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.utils.AuthUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,7 @@ public class HouseholdConsumptionController {
 
     private final ConsumptionRecordCommandService consumptionRecordCommandService;
     private final ConsumptionRecordQueryService consumptionRecordQueryService;
+    private final AuthUtil authUtil;
 
     // 가계부 일일 소비 등록
     @Operation(
@@ -45,10 +48,10 @@ public class HouseholdConsumptionController {
     })
     @PostMapping("/daily")
     public ApiResponse<ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO> postDailyConsumptionRecord(
-            @Valid @RequestBody HouseholdConsumptionRequest.DailyConsumptionCreateDTO request){
+            @Valid @RequestBody HouseholdConsumptionRequest.DailyConsumptionCreateDTO request, HttpServletRequest servletRequest){
 
-        // 로그인 전까지 userId 1로 임시 세팅
-        ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response = consumptionRecordCommandService.saveDailyConsumptionRecord(1L, request);
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO response = consumptionRecordCommandService.saveDailyConsumptionRecord(userId, request);
         return ApiResponse.onSuccess(response);
     }
 
@@ -69,9 +72,9 @@ public class HouseholdConsumptionController {
     })
     @PatchMapping("/daily/{consumptionRecordId}")
     public ApiResponse<String> patchDailyConsumptionRecord(@Valid @RequestBody HouseholdConsumptionRequest.DailyConsumptionCreateDTO request,
-                                                      @PathVariable Long consumptionRecordId){
-        // 로그인 전까지 userId 1로 임시 세팅
-        consumptionRecordCommandService.updateDailyConsumptionRecord(1L, consumptionRecordId, request);
+                                                      @PathVariable Long consumptionRecordId, HttpServletRequest servletRequest){
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        consumptionRecordCommandService.updateDailyConsumptionRecord(userId, consumptionRecordId, request);
 
         return ApiResponse.onSuccess("일일 소비 수정 성공");
     }
@@ -91,9 +94,9 @@ public class HouseholdConsumptionController {
             @Parameter(name = "consumptionRecordId", description = "삭제하려는 소비 기록 아이디", example = "1", required = true),
     })
     @DeleteMapping("/daily/{consumptionRecordId}")
-    public ApiResponse<String> deleteDailyConsumptionRecord(@PathVariable Long consumptionRecordId){
-        // 로그인 전까지 userId 1로 임시 세팅
-        consumptionRecordCommandService.deleteDailyConsumptionRecord(1L, consumptionRecordId);
+    public ApiResponse<String> deleteDailyConsumptionRecord(@PathVariable Long consumptionRecordId, HttpServletRequest servletRequest){
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        consumptionRecordCommandService.deleteDailyConsumptionRecord(userId, consumptionRecordId);
 
         return ApiResponse.onSuccess("일일 소비 삭제 성공");
     }
@@ -114,10 +117,10 @@ public class HouseholdConsumptionController {
             @Parameter(name = "consumptionRecordId", description = "조회하려는 소비 기록 아이디", example = "1", required = true),
     })
     @GetMapping("/daily/{consumptionRecordId}")
-    public ApiResponse<HouseholdConsumptionResponse.DailyConsumptionDetailDTO> getDailyConsumptionRecord(@PathVariable Long consumptionRecordId){
+    public ApiResponse<HouseholdConsumptionResponse.DailyConsumptionDetailDTO> getDailyConsumptionRecord(@PathVariable Long consumptionRecordId, HttpServletRequest servletRequest){
 
-        // 로그인 전까지 userId 1로 임시 세팅
-        HouseholdConsumptionResponse.DailyConsumptionDetailDTO response = consumptionRecordQueryService.getDailyConsumptionRecordDetail(1L, consumptionRecordId);
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        HouseholdConsumptionResponse.DailyConsumptionDetailDTO response = consumptionRecordQueryService.getDailyConsumptionRecordDetail(userId, consumptionRecordId);
         return ApiResponse.onSuccess(response);
     }
 
@@ -138,9 +141,9 @@ public class HouseholdConsumptionController {
     })
     @GetMapping("/monthly")
     public ApiResponse<HouseholdConsumptionResponse.MonthlyHistoryResponseDTO> getConsumptionRecordByMonth(@RequestParam Integer year, @RequestParam Integer month,
-                                                                                                           @RequestParam(required = false) Long cursorId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        HouseholdConsumptionResponse.MonthlyHistoryResponseDTO response = consumptionRecordQueryService.getMonthlyConsumptionRecords(1L, year, month, cursorId);
+                                                                                                           @RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        HouseholdConsumptionResponse.MonthlyHistoryResponseDTO response = consumptionRecordQueryService.getMonthlyConsumptionRecords(userId, year, month, cursorId);
         return ApiResponse.onSuccess(response);
     }
 
@@ -160,10 +163,10 @@ public class HouseholdConsumptionController {
     })
     @GetMapping("/calendar")
     public ApiResponse<HouseholdConsumptionResponse.CalendarDateAmountMapDTO> getConsumptionRecordByMonthInCalendar(@RequestParam Integer year,
-                                                                                                                 @RequestParam Integer month)
+                                                                                                                 @RequestParam Integer month, HttpServletRequest servletRequest)
     {
-        // 로그인 전까지 userId 1로 임시 세팅
-        HouseholdConsumptionResponse.CalendarDateAmountMapDTO response = consumptionRecordQueryService.getMonthlyConsumptionCalendar(1L, year, month);
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        HouseholdConsumptionResponse.CalendarDateAmountMapDTO response = consumptionRecordQueryService.getMonthlyConsumptionCalendar(userId, year, month);
         return ApiResponse.onSuccess(response);
     }
 
@@ -183,11 +186,12 @@ public class HouseholdConsumptionController {
             @Parameter(name = "day", description = "조회하려는 소비 일", example = "23", required = true),
     })
     @GetMapping("/calendar/daily")
-    public ApiResponse<HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO> getConsumptionRecordByMonthAndDayInCalendar(@RequestParam Integer year, @RequestParam Integer month, @RequestParam Integer day)
+    public ApiResponse<HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO> getConsumptionRecordByMonthAndDayInCalendar(@RequestParam Integer year, @RequestParam Integer month,
+                                                                                                                               @RequestParam Integer day, HttpServletRequest servletRequest)
     {
 
-        // 로그인 전까지 userId 1로 임시 세팅
-        HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO response = consumptionRecordQueryService.getCalendarDailyConsumptionRecordsDetail(1L, year, month, day);
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO response = consumptionRecordQueryService.getCalendarDailyConsumptionRecordsDetail(userId, year, month, day);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -6,6 +6,7 @@ import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionCo
 import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.utils.AuthUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +31,7 @@ public class FixedConsumptionController {
 
     private final FixedConsumptionCommandService fixedConsumptionCommandService;
     private final FixedConsumptionQueryService fixedConsumptionQueryService;
+    private final AuthUtil authUtil;
 
     @Operation(
             summary = "고정비 등록 API",
@@ -42,9 +45,10 @@ public class FixedConsumptionController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @PostMapping()
-    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCreateResultDTO> postFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        FixedConsumptionResponse.FixedConsumptionCreateResultDTO response = fixedConsumptionCommandService.saveFixedConsumption(1L, request);
+    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCreateResultDTO> postFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request,
+                                                                                                      HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        FixedConsumptionResponse.FixedConsumptionCreateResultDTO response = fixedConsumptionCommandService.saveFixedConsumption(userId, request);
         return ApiResponse.onSuccess(response);
     }
 
@@ -65,9 +69,9 @@ public class FixedConsumptionController {
     })
     @PatchMapping("/{fixedConsumptionId}")
     public ApiResponse<String> patchFixedConsumption(@Valid @RequestBody FixedConsumptionRequest.FixedConsumptionCreateDTO request,
-                                               @PathVariable Long fixedConsumptionId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        fixedConsumptionCommandService.updateFixedConsumption(1L, fixedConsumptionId, request);
+                                               @PathVariable Long fixedConsumptionId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        fixedConsumptionCommandService.updateFixedConsumption(userId, fixedConsumptionId, request);
         return ApiResponse.onSuccess("고정비 수정 성공");
     }
 
@@ -86,9 +90,9 @@ public class FixedConsumptionController {
             @Parameter(name = "fixedConsumptionId", description = "삭제하려는 고정비 아이디", example = "1", required = true),
     })
     @DeleteMapping("/{fixedConsumptionId}")
-    public ApiResponse<String> deleteFixedConsumption(@PathVariable Long fixedConsumptionId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        fixedConsumptionCommandService.deleteFixedConsumption(1L, fixedConsumptionId);
+    public ApiResponse<String> deleteFixedConsumption(@PathVariable Long fixedConsumptionId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        fixedConsumptionCommandService.deleteFixedConsumption(userId, fixedConsumptionId);
         return ApiResponse.onSuccess("고정비 삭제 성공");
     }
 
@@ -105,9 +109,9 @@ public class FixedConsumptionController {
             @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 consumptionRecordId). 첫 요청 시 생략", example = "3", required = false)
     })
     @GetMapping("list")
-    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCursorResultDTO> getFixedConsumptions(@RequestParam(required = false) Long cursorId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        FixedConsumptionResponse.FixedConsumptionCursorResultDTO response = fixedConsumptionQueryService.getFixedConsumptions(1L, cursorId);
+    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCursorResultDTO> getFixedConsumptions(@RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        FixedConsumptionResponse.FixedConsumptionCursorResultDTO response = fixedConsumptionQueryService.getFixedConsumptions(userId, cursorId);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -80,9 +80,9 @@ public class RoutineController {
     })
     @Parameter(name = "cursorId", description = "커서(이전 요청에서 마지막 소비 루틴 아이디), 첫번째 요청일 시에는 파라미터에 포함하지 않아도 됩니다.", example = "10", required = false)
     @GetMapping("/users")
-    public ApiResponse<RoutineResponse.MyRoutineListDTO> getMyRoutines(@RequestParam(required = false) Long cursorId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        RoutineResponse.MyRoutineListDTO response = routineQueryService.getMyRoutineList(1L, cursorId);
+    public ApiResponse<RoutineResponse.MyRoutineListDTO> getMyRoutines(@RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        RoutineResponse.MyRoutineListDTO response = routineQueryService.getMyRoutineList(userId, cursorId);
         return ApiResponse.onSuccess(response);
     }
 
@@ -121,9 +121,9 @@ public class RoutineController {
             @Parameter(name = "routineId", description = "조회하려는 소비 루틴 아이디", example = "1", required = true),
     })
     @GetMapping("/users/{routineId}")
-    public ApiResponse<RoutineResponse.RoutineDetailDTO> getMyDetailRoutine(@PathVariable Long routineId) {
-        // 로그인 전까지 userId 1로 임시 세팅
-        RoutineResponse.RoutineDetailDTO response = routineQueryService.getUserRoutineDetail(1L, routineId);
+    public ApiResponse<RoutineResponse.RoutineDetailDTO> getMyDetailRoutine(@PathVariable Long routineId, HttpServletRequest servletRequest) {
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        RoutineResponse.RoutineDetailDTO response = routineQueryService.getUserRoutineDetail(userId, routineId);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/user/dto/KakaoDTO.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/KakaoDTO.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,7 @@ public class KakaoDTO {
         private int refresh_token_expires_in;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     @Getter @Setter @NoArgsConstructor
     public static class KakaoProfile {
         private Long id;
@@ -63,6 +65,7 @@ public class KakaoDTO {
 
             private String email;
 
+            @JsonIgnoreProperties(ignoreUnknown = true)
             @Getter @Setter @NoArgsConstructor
             public static class Profile {
                 private String nickname;
@@ -75,6 +78,9 @@ public class KakaoDTO {
 
                 @JsonProperty("is_default_nickname")
                 private Boolean isDefaultNickname;
+
+                @JsonProperty("is_default_image")
+                private Boolean isDefaultImage;
             }
         }
     }

--- a/src/main/java/com/server/money_touch/domain/user/entity/CustomUserDetails.java
+++ b/src/main/java/com/server/money_touch/domain/user/entity/CustomUserDetails.java
@@ -12,14 +12,14 @@ import java.util.List;
 public class CustomUserDetails implements UserDetails, Serializable {
 
     private final Long id;
-    private final String nickname;
+    private final String email;
     private final String password;
     private final String role;
     private final AuthType authType;
 
     public CustomUserDetails(User user, String password) {
         this.id = user.getId();
-        this.nickname = user.getNickname();
+        this.email = user.getEmail();
         this.role = user.getRole().name();
         this.authType = user.getAuthType();
         this.password = password; // local login 비밀번호
@@ -35,7 +35,7 @@ public class CustomUserDetails implements UserDetails, Serializable {
     // 사용자의 닉네임을 반환
     @Override
     public String getUsername() {
-        return nickname;
+        return email;
     }
 
     // 사용자의 password 반환

--- a/src/main/java/com/server/money_touch/global/s3/S3testController.java
+++ b/src/main/java/com/server/money_touch/global/s3/S3testController.java
@@ -2,6 +2,7 @@ package com.server.money_touch.global.s3;
 
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,9 +24,9 @@ public class S3testController {
     /*consumes ~, @RequestParam ~ , String url = ~ 작성해야 업로드 가능. dir 은 저장 폴더명입니다.
     프로필 이미지라면 dirName: "profile", 소비 루틴 기록 이미지라면 "record" 라고 작성하는 것을 추천드립니다.*/
 
-    public ApiResponse<String> uploadTest(@RequestParam("file") MultipartFile file) {
+    public ApiResponse<String> uploadTest(@RequestParam("file") MultipartFile file, HttpServletRequest request) {
         try {
-            String url = s3Manager.upload(file, "test");
+            String url = s3Manager.upload(file, "profile");
             return ApiResponse.onSuccess(url);
         } catch (Exception e) {
             return ApiResponse.onFailure("S3_UPLOAD_FAIL", e.getMessage(), null);

--- a/src/main/java/com/server/money_touch/global/test/TestController.java
+++ b/src/main/java/com/server/money_touch/global/test/TestController.java
@@ -12,7 +12,7 @@ public class TestController {
 
     @GetMapping("/test")
     public String test() {
-        return "Hello World!";
+        return "test";
     }
 
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
>- #90 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 가계부 관련 기능에서 기존의 하드 코딩된 userId 부분을 제거하고, 가계부 JWT 기반 사용자 식별 로직 적용
- `CustomUserDetails`의 `nickname` 필드를 `email`로 변경
- `S3testController`의 디렉토리명을 `profile`로 변경 (프론트에서 프로필 이미지 등록 시 해당 API를 사용하고 계신다고 해서, 디렉토리 명을 변경했습니다.)

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
```
ALTER TABLE user MODIFY auth_type ENUM('LOCAL', 'KAKAO') NOT NULL;
```
로컬 DB에서 해당 명령어 실행 후, 카카오 소셜 로그인 및 로컬 로그인 후 403 에러가 나지 않는지 확인 부탁드립니다. 배포 DB는 제가 위 명령어로 변경해 놨습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
