### PR TITLE
[#90] Fix: 이미지 업로드 접근 허용

### DIFF
--- a/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", // 로그인, 회원가입
                                 "/", "/index.html", "/css/**", "/js/**", "/images/**", "/test", // Spring Boot의 정적 리소스 기본 경로
-                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html") // Swagger 문서 허용
+                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", // Swaggger 문서
+                                "/api/test/s3") // 프로필 이미지 업로드
                         .permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자 페이지 접근 제어
                         .anyRequest().authenticated() // 나머지는 인증 필요

--- a/src/main/java/com/server/money_touch/global/s3/S3testController.java
+++ b/src/main/java/com/server/money_touch/global/s3/S3testController.java
@@ -21,14 +21,13 @@ public class S3testController {
     // 이미지를 업로드하는 각 서비스에 추가해주세요.
     private final S3Manager s3Manager;
 
-    @Operation(summary = "이미지 업로드 테스트 API", description = "Multipart 파일 업로드")
+    @Operation(summary = "프로필 이미지 업로드 테스트 API", description = "Multipart 파일 업로드")
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     /*consumes ~, @RequestParam ~ , String url = ~ 작성해야 업로드 가능. dir 은 저장 폴더명입니다.
     프로필 이미지라면 dirName: "profile", 소비 루틴 기록 이미지라면 "record" 라고 작성하는 것을 추천드립니다.*/
 
     public ApiResponse<String> uploadTest(@RequestParam("file") MultipartFile file) {
         try {
-            log.info("test");
             String url = s3Manager.upload(file, "profile");
             return ApiResponse.onSuccess(url);
         } catch (Exception e) {

--- a/src/main/java/com/server/money_touch/global/s3/S3testController.java
+++ b/src/main/java/com/server/money_touch/global/s3/S3testController.java
@@ -4,6 +4,7 @@ import com.server.money_touch.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/test/s3")
@@ -24,8 +26,9 @@ public class S3testController {
     /*consumes ~, @RequestParam ~ , String url = ~ 작성해야 업로드 가능. dir 은 저장 폴더명입니다.
     프로필 이미지라면 dirName: "profile", 소비 루틴 기록 이미지라면 "record" 라고 작성하는 것을 추천드립니다.*/
 
-    public ApiResponse<String> uploadTest(@RequestParam("file") MultipartFile file, HttpServletRequest request) {
+    public ApiResponse<String> uploadTest(@RequestParam("file") MultipartFile file) {
         try {
+            log.info("test");
             String url = s3Manager.upload(file, "profile");
             return ApiResponse.onSuccess(url);
         } catch (Exception e) {


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
X

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 이미지 업로드 테스트 API가 회원가입 시 프로필 이미지 업로드로 사용되기 때문에 SecurityConfig에서 접근을 허용시킴

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
