### PR TITLE
[#95] 🐛Fix: 가계부 커서 조회 개선 및 예산 등록 예외 처리, 회원가입 초기 예산&소비 관련 데이터 생성 추가

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -6,8 +6,6 @@ import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
 import com.server.money_touch.domain.budget.service.budget.BudgetQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
-import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
-import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.global.utils.AuthUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
@@ -68,7 +66,7 @@ public class BudgetController {
     // 한 달 예산 내역 조회
     @Operation(
             summary = "한 달 예산 내역 조회 API",
-            description = "아이디와 일치하는 한 달 예산 내역 조회 API 입니다. (소비 루틴 등록 시 나의 한 달 예산 정보를 불러오는 용도)"
+            description = "아이디와 일치하는 한 달 예산 내역 조회 API 입니다. (소비 루틴 등록 및 예산 수정 시 나의 한 달 예산 정보를 불러오는 용도)"
     )
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),

--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -38,8 +38,12 @@ public class BudgetController {
     // 가계부 한 달 예산 등록
     @Operation(
             summary = "월간 예산 등록 또는 수정 API",
-            description = "총 예산과 기본, 사용자 정의, 소비 루틴 카테고리별 예산 목록을 RequestBody로 입력받아 해당 월의 예산을 등록하거나 수정합니다. " +
-                    "이미 등록된 예산이 있는 경우에는 수정됩니다. 등록하거나 수정할 내 카테고리나 소비 루틴 카테고리가 없다면 해당 리스트는 요청에서 생략하셔도 됩니다."
+            description = "총 예산과 기본, 사용자 정의 카테고리별 예산 목록을 RequestBody로 입력받아 해당 월의 예산을 등록하거나 수정합니다. " +
+                    "이미 등록된 예산이 있는 경우에는 수정됩니다.\n\n" +
+                    "- `defaultCategoryBudgets`: 기본 소비 카테고리 예산 목록으로, 필수입니다.\n" +
+                    "- `customCategoryBudgets`: 사용자가 직접 생성한 내 카테고리 예산 목록으로, 선택입니다.\n" +
+                    "- `routineCategoryBudgets`: 소비 루틴 카테고리 예산 목록입니다. 소비 루틴을 등록한 적이 있는 사용자이거나, 타인의 소비 루틴을 내 예산에 반영하여 소비 루틴 카테고리가 있는 경우에만 포함합니다.\n\n" +
+                    "예산 등록 또는 수정 시, 사용자가 해당하는 예산 카테고리를 제공하지 않으려면 해당 리스트는 생략 가능합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.BudgetCreateResultDTO.class)
     @ApiErrorCodeExamples({
@@ -48,6 +52,7 @@ public class BudgetController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_ALREADY_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_CATEGORY_TYPE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_CATEGORY_NOT_ALLOWED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
@@ -56,8 +61,6 @@ public class BudgetController {
                                                                         HttpServletRequest servletRequest) {
 
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
-        log.info("userId, {}", userId);
-
         BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(userId, request);
         return ApiResponse.onSuccess(response);
     }
@@ -87,12 +90,12 @@ public class BudgetController {
     @Operation(
             summary = "예산 아이디 및 한 달 총 소비 금액 조회 API",
             description = "한 달 예산을 기준으로 예산 아이디 및 현재까지의 총 소비 금액을 반환합니다. " +
-                    "등록된 예산이 없는 경우, 에러 메시지를 반환합니다."
+                    "이번 달 등록된 예산이 없는 경우, totalConsumptionAmount는 0원을 반환합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.TotalConsumptionResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_EXIST"),
+//            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
@@ -97,7 +97,18 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
 
             updateCategoryBudgetsByType(request.getDefaultCategoryBudgets(), user, budget, CategoryType.DEFAULT, existingMapByType.getOrDefault(CategoryType.DEFAULT, Map.of()));
             updateCategoryBudgetsByType(request.getCustomCategoryBudgets(), user, budget, CategoryType.CUSTOM, existingMapByType.getOrDefault(CategoryType.CUSTOM, Map.of()));
-            updateCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY, existingMapByType.getOrDefault(CategoryType.ROUTINE_CATEGORY, Map.of()));
+
+            // 소비 루틴 카테고리는 소비 루틴을 등로한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 가능
+            if (hasRoutineCategoryBudget(request)) {
+                boolean hasRoutineData = budget.getIsFromRoutine()
+                        || consumptionCategoryRepository.existsByUserAndBudgetCategoryType(user, CategoryType.ROUTINE_CATEGORY);
+
+                if (!hasRoutineData) {
+                    throw new ErrorHandler(ErrorStatus.ROUTINE_CATEGORY_NOT_ALLOWED);
+                }
+
+                updateCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY, existingMapByType.getOrDefault(CategoryType.ROUTINE_CATEGORY, Map.of()));
+            }
 
             log.info("예산 수정 완료 - userId: {}, budgetId: {}", userId, budget.getId());
         } else {
@@ -107,7 +118,18 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
 
             saveCategoryBudgetsByType(request.getDefaultCategoryBudgets(), user, budget, CategoryType.DEFAULT);
             saveCategoryBudgetsByType(request.getCustomCategoryBudgets(), user, budget, CategoryType.CUSTOM);
-            saveCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY);
+
+            // 소비 루틴 카테고리는 소비 루틴을 등로한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 가능
+            if (hasRoutineCategoryBudget(request)) {
+                boolean hasRoutineData = budget.getIsFromRoutine()
+                        || consumptionCategoryRepository.existsByUserAndBudgetCategoryType(user, CategoryType.ROUTINE_CATEGORY);
+
+                if (!hasRoutineData) {
+                    throw new ErrorHandler(ErrorStatus.ROUTINE_CATEGORY_NOT_ALLOWED);
+                }
+
+                saveCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY);
+            }
 
             log.info("예산 등록 완료 - userId: {}, budgetId: {}", user.getId(), budget.getId());
         }
@@ -329,5 +351,9 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
         Budget newBudget = BudgetConverter.toBudgetEntity(user, 0);
 
         return budgetRepository.save(newBudget);
+    }
+
+    private boolean hasRoutineCategoryBudget(BudgetRequest.BudgetCreateDTO request) {
+        return request.getRoutineCategoryBudgets() != null && !request.getRoutineCategoryBudgets().isEmpty();
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/HouseholdConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/controller/HouseholdConsumptionController.java
@@ -137,7 +137,7 @@ public class HouseholdConsumptionController {
     @Parameters({
             @Parameter(name = "year", description = "조회하려는 소비 연도", example = "2025", required = true),
             @Parameter(name = "month", description = "조회하려는 소비 월", example = "7", required = true),
-            @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 consumptionRecordId). 첫 요청 시 생략", example = "3", required = false)
+            @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 cursorId). 첫 요청 시 생략", example = "3", required = false)
     })
     @GetMapping("/monthly")
     public ApiResponse<HouseholdConsumptionResponse.MonthlyHistoryResponseDTO> getConsumptionRecordByMonth(@RequestParam Integer year, @RequestParam Integer month,
@@ -172,8 +172,13 @@ public class HouseholdConsumptionController {
 
     // 가계부 달력 특정 일의 소비 내역 조회
     @Operation(
-            summary = "달력 - 특정 날짜 소비 내역 조회 API",
-            description = "입력한 연도(year), 월(month), 일(day)에 해당하는 소비 내역을 조회합니다. 해당 날짜의 소비 내역이 없다면, 빈 리스트를 반환합니다."
+            summary = "달력 - 특정 날짜 소비 내역 조회 (커서 기반 무한 스크롤)",
+            description = """
+            입력한 연도(year), 월(month), 일(day)에 해당하는 소비 내역을 커서 기반으로 조회합니다.  
+            응답은 소비일 기준 최신순이며, `cursorId`를 기준으로 이후 내역을 무한 스크롤 방식으로 불러올 수 있습니다.  
+            - `cursorId`가 없을 경우 첫 페이지를 반환합니다.  
+            - 소비 내역이 없는 경우 `items`는 빈 배열로 응답됩니다.
+            """
     )
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
@@ -184,14 +189,15 @@ public class HouseholdConsumptionController {
             @Parameter(name = "year", description = "조회하려는 소비 연도", example = "2025", required = true),
             @Parameter(name = "month", description = "조회하려는 소비 월", example = "7", required = true),
             @Parameter(name = "day", description = "조회하려는 소비 일", example = "23", required = true),
+            @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 cursorId). 첫 요청 시 생략", example = "3", required = false)
     })
     @GetMapping("/calendar/daily")
-    public ApiResponse<HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO> getConsumptionRecordByMonthAndDayInCalendar(@RequestParam Integer year, @RequestParam Integer month,
-                                                                                                                               @RequestParam Integer day, HttpServletRequest servletRequest)
+    public ApiResponse<HouseholdConsumptionResponse.CalendarDailyConsumeSliceResponse> getConsumptionRecordByMonthAndDayInCalendar(@RequestParam Integer year, @RequestParam Integer month,
+                                                                                                                               @RequestParam Integer day, @RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest)
     {
 
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
-        HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO response = consumptionRecordQueryService.getCalendarDailyConsumptionRecordsDetail(userId, year, month, day);
+        HouseholdConsumptionResponse.CalendarDailyConsumeSliceResponse response = consumptionRecordQueryService.getCalendarDailyConsumptionRecordsDetail(userId, year, month, day, cursorId);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
@@ -5,9 +5,11 @@ import com.server.money_touch.domain.consumptionRecord.dto.HouseholdConsumptionR
 import com.server.money_touch.domain.consumptionRecord.dto.HouseholdConsumptionResponse;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.consumptionRecord.projection.DailyConsumptionItemDetailProjection;
 import com.server.money_touch.domain.consumptionRecord.projection.DailyConsumptionItemProjection;
 import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.user.entity.User;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -54,20 +56,7 @@ public class ConsumptionRecordConverter {
                 .build();
     }
 
-
-    // 달력 - 특정 날짜의 소비 내역 조회 응답
-    public static HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO toCalendarDailyConsumeDetailDTO(
-            LocalDate targetDate,
-            List<HouseholdConsumptionResponse.ConsumeItemDTO> items
-    ) {
-        return HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO.builder()
-                .date(targetDate.toString())
-                .items(items)
-                .itemSize(items.size())
-                .build();
-    }
-
-    // 달력 무한스크롤 - 한달 소비 기록 조회 목록 응답 정보
+    // 소비 내역 무한스크롤 - 한달 소비 기록 조회 목록 응답 정보
     public static HouseholdConsumptionResponse.MonthlyHistoryResponseDTO toMonthlyHistoryResponseDTO(
             List<HouseholdConsumptionResponse.DailyHistoryDTO> dailyHistory,
             boolean isFirst,
@@ -84,7 +73,7 @@ public class ConsumptionRecordConverter {
                 .build();
     }
 
-    // 달력 무한스크롤 - 날짜별 소비 기록 조회 응답 정보
+    // 소비 내역 무한스크롤 - 날짜별 소비 기록 조회 응답 정보
     public static HouseholdConsumptionResponse.DailyHistoryDTO toDailyHistoryDTO(LocalDate date, List<HouseholdConsumptionResponse.DailyRecordDTO> records) {
         return HouseholdConsumptionResponse.DailyHistoryDTO.builder()
                 .date(date.toString())
@@ -93,7 +82,7 @@ public class ConsumptionRecordConverter {
                 .build();
     }
 
-    // 달력 무한스크롤 - 날짜별 상세 소비 기록 조회 응답 정보
+    // 소비 내역 무한스크롤 - 날짜별 상세 소비 기록 조회 응답 정보
     public static HouseholdConsumptionResponse.DailyRecordDTO toDailyRecordDTO(DailyConsumptionItemProjection projection) {
         return HouseholdConsumptionResponse.DailyRecordDTO.builder()
                 .consumptionRecordId(projection.getConsumptionRecordId())
@@ -118,6 +107,33 @@ public class ConsumptionRecordConverter {
                 .wiseCount(0)
                 .wasteCount(0)
                 .viewCount(0)
+                .build();
+    }
+
+    // 달력 - 특정 날짜의 소비 내역 무한스크롤 조회 응답
+    public static HouseholdConsumptionResponse.CalendarDailyConsumeSliceResponse toCalendarDailyConsumeSliceResponse(
+            LocalDate targetDate,
+            Slice<DailyConsumptionItemDetailProjection> slice,
+            Long nextCursorId,
+            boolean isFirst
+    ) {
+        List<HouseholdConsumptionResponse.ConsumeItemDTO> items = slice.getContent().stream()
+                .map(p -> HouseholdConsumptionResponse.ConsumeItemDTO.builder()
+                        .consumptionRecordId(p.getConsumptionRecordId())
+                        .categoryName(p.getCategoryName())
+                        .content(p.getContent())
+                        .amount(p.getAmount())
+                        .build())
+                .toList();
+
+        return HouseholdConsumptionResponse.CalendarDailyConsumeSliceResponse.builder()
+                .date(targetDate.toString())
+                .items(items)
+                .itemSize(items.size())
+                .isFirst(isFirst)
+                .isLast(!slice.hasNext())
+                .hasNext(slice.hasNext())
+                .nextCursorId(nextCursorId)
                 .build();
     }
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/HouseholdConsumptionResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/HouseholdConsumptionResponse.java
@@ -161,41 +161,29 @@ public class HouseholdConsumptionResponse {
     @Getter
     @Builder
     @AllArgsConstructor
-    @Schema(description = "달력 특정 날짜의 소비 상세 내역", example = """
-{
-  "date": "2025-07-23",
-  "items": [
-    {
-      "consumptionRecordId": 1,
-      "categoryName": "카페",
-      "content": "스타벅스",
-      "amount": 5000
-    },
-    {
-      "consumptionRecordId": 2,
-      "categoryName": "편의점",
-      "content": "CU",
-      "amount": 3500
-    },
-    {
-      "consumptionRecordId": 3,
-      "categoryName": "교통",
-      "content": "버스",
-      "amount": 7000
-    }
-  ],
-  "itemSize": 3
-}
-""")    public static  class CalendarDailyConsumeDetailDTO {
+    @Schema(description = "달력 - 특정 날짜 소비 내역 커서 기반 응답 DTO")
+    public static class CalendarDailyConsumeSliceResponse {
 
-        @Schema(description = "소비 날짜", example = "2025-07-02")
+        @Schema(description = "소비 날짜", example = "2025-07-23")
         private String date;
 
-        @Schema(description = "일일 소비 항목 목록")
-        private List<HouseholdConsumptionResponse.ConsumeItemDTO> items;
+        @Schema(description = "소비 항목 목록")
+        private List<ConsumeItemDTO> items;
 
-        @Schema(description = "일일 소비 항목 개수", example = "3")
+        @Schema(description = "소비 항목 개수", example = "3")
         private Integer itemSize;
+
+        @Schema(description = "첫 페이지 여부", example = "true")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        private Boolean isLast;
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private Boolean hasNext;
+
+        @Schema(description = "다음 커서 ID", example = "17")
+        private Long nextCursorId;
     }
 
     @Getter

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionCategory/ConsumptionCategoryRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionCategory/ConsumptionCategoryRepository.java
@@ -30,4 +30,6 @@ public interface ConsumptionCategoryRepository extends JpaRepository<Consumption
     List<ConsumptionCategory> findAllByUserIdAndNames(@Param("userId") Long userId, @Param("names") List<String> names);
 
     List<ConsumptionCategory> findAllByUserAndBudgetCategoryType(User user, CategoryType type);
+
+    boolean existsByUserAndBudgetCategoryType(User user, CategoryType budgetCategoryType);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryCustom.java
@@ -11,7 +11,9 @@ import java.util.List;
 
 public interface ConsumptionRecordRepositoryCustom {
     // 사용자의 특정 날짜에 해당하는 소비 기록 목록을 조회
-    List<DailyConsumptionItemDetailProjection> findDailyConsumptionItems(Long userId, LocalDate date);
+    Slice<DailyConsumptionItemDetailProjection> findDailyConsumptionItemsWithCursor(
+            Long userId, LocalDateTime start, LocalDateTime end,
+            Long cursorId, LocalDateTime cursorConsumeDate, int pageSize);
 
     // 특정 유저의 날짜별 소비 금액을 문자열 날짜 기준으로 집계하여 반환
     List<DailyAmountProjection> findDailyTotalAmounts(Long userId, LocalDate startDate, LocalDate endDate);

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
@@ -34,24 +34,38 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
     QFixedConsumption fixed = QFixedConsumption.fixedConsumption;
 
     /**
-     * 사용자의 특정 날짜에 해당하는 소비 기록 목록을 조회합니다.
-     * - 소비 기록에는 소비 금액, 내용, 카테고리명이 포함됩니다.
-     * - 소비 시간(consumeDate) 기준 오름차순(= 먼저 소비된 순서)으로 정렬됩니다.
+     * 특정 날짜의 소비 내역을 커서 기반으로 페이징하여 조회합니다.
+     *
+     * - 기준 날짜(start ~ end) 사이의 소비 내역 중에서
+     * - (consumeDate, id) 기준으로 내림차순 정렬된 데이터에 대해
+     * - 커서 기반 페이징을 적용하여 Slice 형태로 반환합니다.
      *
      * @param userId 사용자 ID
-     * @param date 조회할 날짜 (yyyy-MM-dd)
-     * @return DailyConsumptionItemProjection 리스트 (DTO 형태)
+     * @param start 해당 날짜의 시작 시각 (예: 2025-07-31T00:00)
+     * @param end 해당 날짜의 종료 시각 (예: 2025-07-31T23:59:59)
+     * @param cursorId 마지막으로 조회한 소비 기록 ID (null이면 첫 페이지)
+     * @param cursorConsumeDate cursorId에 해당하는 소비 일시
+     * @param pageSize 한 페이지당 데이터 개수
+     * @return Slice<DailyConsumptionItemDetailProjection>
      */
     @Override
-    public List<DailyConsumptionItemDetailProjection> findDailyConsumptionItems(Long userId, LocalDate date) {
-        // 입력된 날짜의 시작 시간 (00:00:00)
-        LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+    public Slice<DailyConsumptionItemDetailProjection> findDailyConsumptionItemsWithCursor(
+            Long userId, LocalDateTime start, LocalDateTime end,
+            Long cursorId, LocalDateTime cursorConsumeDate, int pageSize) {
 
-        log.debug("소비 내역 조회 - 날짜: {}", startOfDay.toLocalDate());
+        // 기본 조건: 사용자 ID 일치 + 조회일 범위 내 소비 내역
+        BooleanExpression baseCondition = record.user.id.eq(userId)
+                .and(record.consumeDate.between(start, end));
 
-        // 최신순 정렬 + 필요한 컬럼만 조회하여 Projection 반환
-        return queryFactory
+        // 커서 조건: (consumeDate, id) 기준으로 이전 데이터 조회
+        BooleanExpression cursorPredicate = null;
+        if (cursorId != null && cursorConsumeDate != null) {
+            cursorPredicate = record.consumeDate.lt(cursorConsumeDate)
+                    .or(record.consumeDate.eq(cursorConsumeDate).and(record.id.lt(cursorId)));
+        }
+
+        // 쿼리 실행: 필요한 컬럼만 projection으로 조회
+        List<DailyConsumptionItemDetailProjection> results = queryFactory
                 .select(Projections.fields(
                         DailyConsumptionItemDetailProjection.class,
                         record.id.as("consumptionRecordId"),
@@ -63,12 +77,19 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
                 ))
                 .from(record)
                 .join(record.consumptionCategory, category)
-                .where(
-                        record.user.id.eq(userId),
-                        record.consumeDate.between(startOfDay, endOfDay)
-                )
+                .where(baseCondition.and(cursorPredicate)) // 기본 조건 + 커서 조건
                 .orderBy(record.consumeDate.desc(), record.id.desc()) // 최신순 정렬
+                .limit(pageSize + 1) // 다음 페이지 존재 여부 확인을 위한 +1
                 .fetch();
+
+        // hasNext 판단 및 초과한 1개 제거
+        boolean hasNext = results.size() > pageSize;
+        if (hasNext) {
+            results.remove(results.size() - 1);
+        }
+
+        // SliceImpl로 반환 (Pageable은 의미상으로만 사용)
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 
 

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryService.java
@@ -11,12 +11,12 @@ public interface ConsumptionRecordQueryService {
     // 가계부 일일 소비 내역 조회
     HouseholdConsumptionResponse.DailyConsumptionDetailDTO getDailyConsumptionRecordDetail(@ExistUser Long userId, @ExistConsumptionRecord Long consumptionRecordId);
 
-    // 가계부 달력 - 특정 날짜의 소비 내역 조회
-    HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO getCalendarDailyConsumptionRecordsDetail(@ExistUser Long userId, int year, int month, int day);
+    // 가계부 해당 월의 소비 내역 목록 조회
+    HouseholdConsumptionResponse.MonthlyHistoryResponseDTO getMonthlyConsumptionRecords(@ExistUser Long userId, int year, int month, Long cursorId);
 
     // 가계부 달력 - 월별 소비 금액 조회
     HouseholdConsumptionResponse.CalendarDateAmountMapDTO getMonthlyConsumptionCalendar(@ExistUser Long userId, int year, int month);
 
-    // 가계부 달력 - 해당 월의 소비 내역 목록 조회
-    HouseholdConsumptionResponse.MonthlyHistoryResponseDTO getMonthlyConsumptionRecords(@ExistUser Long userId, int year, int month, Long cursorId);
+    // 가계부 달력 - 특정 날짜의 소비 내역 조회
+    HouseholdConsumptionResponse.CalendarDailyConsumeSliceResponse getCalendarDailyConsumptionRecordsDetail(@ExistUser Long userId, int year, int month, int day, Long cursorId);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
@@ -161,7 +161,9 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
                 .toList();
 
         // 다음 커서 ID 설정 (마지막 요소의 ID 사용)
-        Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getConsumptionRecordId();
+        Long nextCursorId = (slice.hasNext() && !content.isEmpty())
+                ? content.get(content.size() - 1).getConsumptionRecordId()
+                : null;
 
         log.info("달력 해당 월의 소비 내역 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, year: {}, month: {}, cursorId: {}, nextCursorId: {}", userId, year, month, cursorId, nextCursorId);
 

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
@@ -62,67 +62,7 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
         return ConsumptionRecordConverter.toDailyConsumptionDetailDTO(consumptionRecord, consumptionCategory);
     }
 
-    // 달력에서 특정 날짜의 소비 내역 상세 조회
-    @Override
-    public HouseholdConsumptionResponse.CalendarDailyConsumeDetailDTO getCalendarDailyConsumptionRecordsDetail(Long userId, int year, int month, int day) {
-        // 1. 사용자 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
-
-        // 2. 조회 대상 날짜 생성
-        LocalDate targetDate = LocalDate.of(year, month, day);
-
-        // 3. 해당 날짜의 소비 내역 조회 (Projection 형태)
-        List<DailyConsumptionItemDetailProjection> projections = consumptionRecordRepository.findDailyConsumptionItems(userId, targetDate);
-
-        // 4. Projection → DTO 변환
-        List<HouseholdConsumptionResponse.ConsumeItemDTO> items = projections.stream()
-                .map(p -> HouseholdConsumptionResponse.ConsumeItemDTO.builder()
-                        .consumptionRecordId(p.getConsumptionRecordId())
-                        .categoryName(p.getCategoryName())
-                        .content(p.getContent())
-                        .amount(p.getAmount())
-                        .build())
-                .toList();
-
-        log.info("달력 특정 날짜의 소비 내역 조회 완료 -userId: {}, targetDate: {}", userId, targetDate);
-
-        // 5. 변환된 결과를 응답 DTO로 매핑하여 반환
-        return ConsumptionRecordConverter.toCalendarDailyConsumeDetailDTO(targetDate, items);
-    }
-
-    // 가계부 달력 월별 소비 금액 조회
-    @Override
-    public HouseholdConsumptionResponse.CalendarDateAmountMapDTO getMonthlyConsumptionCalendar(Long userId, int year, int month) {
-        // 1. 사용자 존재 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
-
-        // 2. 해당 월의 시작일과 마지막 날짜 계산
-        LocalDate startDate = LocalDate.of(year, month, 1);
-        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
-
-        // 3. 소비 기록에서 일별 총 소비 금액 조회 (날짜 기준 group by)
-        List<DailyAmountProjection> projections = consumptionRecordRepository
-                .findDailyTotalAmounts(userId, startDate, endDate);
-
-        // 4. 소비일 기준 오름차순 정렬된 Map 생성
-        Map<String, Integer> result = projections.stream()
-                .sorted(Comparator.comparing(DailyAmountProjection::getDate)) // LocalDate 기준 정렬
-                .collect(Collectors.toMap(
-                        p -> p.getDate().toString(),            // key: 날짜 문자열
-                        DailyAmountProjection::getTotalAmount, // value: 총 소비 금액
-                        (v1, v2) -> v1,                         // key 충돌 시 첫 번째 값 유지
-                        LinkedHashMap::new                      // 순서 유지
-                ));
-
-        log.info("달력 월별 소비 금액 조회 완료: userId: {}, year: {}, month: {}", userId, year, month);
-
-        // 5. DTO 생성 후 반환
-        return HouseholdConsumptionResponse.CalendarDateAmountMapDTO.builder().data(result).build();
-    }
-
-    // 가계부 달력 해당 월의 소비 내역 목록 조회 (커서 기반 무한스크롤)
+    // 해당 월의 소비 내역 목록 조회 (커서 기반 무한스크롤)
     @Override
     public HouseholdConsumptionResponse.MonthlyHistoryResponseDTO getMonthlyConsumptionRecords(Long userId, int year, int month, Long cursorId) {
         // 사용자 조회
@@ -165,7 +105,7 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
                 ? content.get(content.size() - 1).getConsumptionRecordId()
                 : null;
 
-        log.info("달력 해당 월의 소비 내역 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, year: {}, month: {}, cursorId: {}, nextCursorId: {}", userId, year, month, cursorId, nextCursorId);
+        log.info("해당 월의 소비 내역 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, year: {}, month: {}, cursorId: {}, nextCursorId: {}", userId, year, month, cursorId, nextCursorId);
 
         // 최종 응답 DTO 반환
         return ConsumptionRecordConverter.toMonthlyHistoryResponseDTO(
@@ -174,5 +114,82 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
                 slice.hasNext(),             // hasNext: 다음 페이지 존재 여부
                 nextCursorId                 // nextCursorId: 다음 요청 시 사용할 커서 ID
         );
+    }
+
+    // 가계부 달력 월별 소비 금액 조회
+    @Override
+    public HouseholdConsumptionResponse.CalendarDateAmountMapDTO getMonthlyConsumptionCalendar(Long userId, int year, int month) {
+        // 1. 사용자 존재 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 해당 월의 시작일과 마지막 날짜 계산
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        // 3. 소비 기록에서 일별 총 소비 금액 조회 (날짜 기준 group by)
+        List<DailyAmountProjection> projections = consumptionRecordRepository
+                .findDailyTotalAmounts(userId, startDate, endDate);
+
+        // 4. 소비일 기준 오름차순 정렬된 Map 생성
+        Map<String, Integer> result = projections.stream()
+                .sorted(Comparator.comparing(DailyAmountProjection::getDate)) // LocalDate 기준 정렬
+                .collect(Collectors.toMap(
+                        p -> p.getDate().toString(),            // key: 날짜 문자열
+                        DailyAmountProjection::getTotalAmount, // value: 총 소비 금액
+                        (v1, v2) -> v1,                         // key 충돌 시 첫 번째 값 유지
+                        LinkedHashMap::new                      // 순서 유지
+                ));
+
+        log.info("달력 월별 소비 금액 조회 완료: userId: {}, year: {}, month: {}", userId, year, month);
+
+        // 5. DTO 생성 후 반환
+        return HouseholdConsumptionResponse.CalendarDateAmountMapDTO.builder().data(result).build();
+    }
+
+    // 달력에서 특정 날짜의 소비 내역 상세 조회 (커서 기반 무한스크롤)
+    @Override
+    public HouseholdConsumptionResponse.CalendarDailyConsumeSliceResponse getCalendarDailyConsumptionRecordsDetail(Long userId, int year, int month, int day, Long cursorId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        LocalDate targetDate = LocalDate.of(year, month, day);
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+
+        // 커서 consumeDate 조회
+        LocalDateTime cursorConsumeDate = null;
+        if (cursorId != null) {
+            cursorConsumeDate = consumptionRecordRepository.findConsumeDateById(cursorId);
+        }
+
+        // 데이터 조회 (Slice)
+        Slice<DailyConsumptionItemDetailProjection> slice = consumptionRecordRepository
+                .findDailyConsumptionItemsWithCursor(userId, startOfDay, endOfDay, cursorId, cursorConsumeDate, PAGE_SIZE);
+
+        List<HouseholdConsumptionResponse.ConsumeItemDTO> items = slice.getContent().stream()
+                .map(p -> HouseholdConsumptionResponse.ConsumeItemDTO.builder()
+                        .consumptionRecordId(p.getConsumptionRecordId())
+                        .categoryName(p.getCategoryName())
+                        .content(p.getContent())
+                        .amount(p.getAmount())
+                        .build())
+                .toList();
+
+        Long nextCursorId = (slice.hasNext() && !items.isEmpty())
+                ? items.get(items.size() - 1).getConsumptionRecordId()
+                : null;
+        boolean isFirst = (cursorId == null);
+
+        log.info("달력 특정 날짜의 소비 내역 상세 조회(커서 기반 무한스크롤) 완료 - userId: {}, year: {}, month: {}, cursorId: {}, nextCursorId: {}", userId, year, month, cursorId, nextCursorId);
+
+        return ConsumptionRecordConverter.toCalendarDailyConsumeSliceResponse(
+                targetDate,
+                slice,
+                nextCursorId,
+                isFirst
+        );
+
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -106,7 +106,7 @@ public class FixedConsumptionController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @Parameters({
-            @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 consumptionRecordId). 첫 요청 시 생략", example = "3", required = false)
+            @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 cursorId). 첫 요청 시 생략", example = "3", required = false)
     })
     @GetMapping("list")
     public ApiResponse<FixedConsumptionResponse.FixedConsumptionCursorResultDTO> getFixedConsumptions(@RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -27,6 +27,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import static com.server.money_touch.global.apiPayload.code.status.ErrorStatus.CONSUMPTION_CATEGORY_NAME_MISSING_IN_REQUEST;
+
 @Tag(name = "가계부 소비 루틴 페이지", description = "가계부 소비 루틴에 관한 API")
 @Slf4j
 @Validated
@@ -52,6 +54,7 @@ public class RoutineController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_ALREADY_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_CATEGORY_NAME_MISSING_IN_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -102,6 +102,14 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             }
         });
 
+        // 8-1. 요청에 포함되지 않은 소비 카테고리 존재 시 예외 처리 (Stream 방식)
+        budgetCategoryMap.keySet().stream()
+                .filter(categoryName -> !requestMap.containsKey(categoryName))
+                .findFirst()
+                .ifPresent(missing -> {
+                    throw new ErrorHandler(CONSUMPTION_CATEGORY_NAME_MISSING_IN_REQUEST);
+                });
+
         // 9. 소비 루틴 저장
         Routine routine = RoutineConverter.toRoutine(user, budget, request);
         routineRepository.save(routine);

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -1,5 +1,11 @@
 package com.server.money_touch.domain.user.service.user;
 
+import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
+import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
+import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
+import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
 import com.server.money_touch.domain.user.converter.AuthConverter;
 import com.server.money_touch.domain.user.dto.KakaoDTO;
 import com.server.money_touch.domain.user.dto.TokenResponse;
@@ -17,6 +23,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -25,14 +34,39 @@ public class AuthService {
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final BudgetCommandService budgetCommandService;
+    private final TotalConsumptionRepository totalConsumptionRepository;
 
     public User oAuthLogin(String accessCode, HttpServletResponse httpServletResponse) {
         KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode);
         KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
         String email = kakaoProfile.getKakaoAccount().getEmail();
 
-        User user = userRepository.findByEmail(email)
-                .orElseGet(() -> createNewUser(kakaoProfile)); // 등록되지않은 회원이면 회원가입
+        // 사용자 존재 여부 확인
+        User user;
+        boolean isNewUser = false;
+
+        if (userRepository.existsByEmail(email)) {
+            user = userRepository.findByEmail(email).get();
+        } else {
+            user = createNewUser(kakaoProfile); // 등록되지않은 회원이면 회원가입
+            isNewUser = true;
+        }
+
+        // ✅ 신규 가입자에 대해서만 예산 및 소비 생성
+        if (isNewUser) {
+            LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+            LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
+
+            Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
+            budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
+
+            totalConsumptionRepository.findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
+                    .orElseGet(() -> totalConsumptionRepository.save(
+                            TotalConsumptionConverter.toTotalConsumption(user))
+                    );
+        }
+
         // 1. User를 기반으로 CustomUserDetails 생성
         CustomUserDetails userDetails = new CustomUserDetails(user, null);
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
@@ -41,6 +75,7 @@ public class AuthService {
         TokenResponse tokenResponse = tokenProvider.generateTokens(authentication);
         // 3. 헤더에 토큰 담기
         httpServletResponse.setHeader("Authorization", "Bearer " + tokenResponse.getAccessToken());
+
         return user;
     }
 
@@ -53,6 +88,7 @@ public class AuthService {
                 Role.USER,
                 AuthType.KAKAO
         );
+
         return userRepository.save(newUser);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
@@ -1,5 +1,11 @@
 package com.server.money_touch.domain.user.service.user;
 
+import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
+import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
+import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
+import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
 import com.server.money_touch.domain.user.converter.UserConverter;
 import com.server.money_touch.domain.user.dto.TokenResponse;
 import com.server.money_touch.domain.user.dto.UserRequest;
@@ -23,6 +29,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,6 +43,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final BudgetCommandService budgetCommandService;
+    private final TotalConsumptionRepository totalConsumptionRepository;
 
     /**
      * 로컬 회원가입
@@ -67,6 +77,20 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 약관 동의 처리
         processAgreements(savedUser, request.getAgreeTerms());
+
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
+
+        // 1. Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
+        Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
+        budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
+
+        // 2. TotalConsumption 조회 or 생성
+        TotalConsumption totalConsumption = totalConsumptionRepository
+                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
+                .orElseGet(() -> totalConsumptionRepository.save(
+                        TotalConsumptionConverter.toTotalConsumption(user))
+                );
 
         log.info("로컬 회원가입 완료 - userId: {}", savedUser.getId());
 

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다."),
     BUDGET_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "BUDGET4004", "한 달 예산 등록 횟수를 초과하였습니다."),
     BUDGET_NOT_EXIST(HttpStatus.NOT_FOUND, "BUDGET_4041", "이번달에 등록된 예산이 없습니다."),
+    ROUTINE_CATEGORY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BUDGET_403", "소비 루틴 카테고리는 소비 루틴을 등록한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 설정할 수 있습니다."),
 
     // 소비 MBTI 관련 에러
     MBTI_NOT_FOUND(HttpStatus.BAD_REQUEST, "MBTI4001", "해당하는 소비 MBTI가 없습니다."),
@@ -36,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CONSUMPTION_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CONSUMPTION_CATEGORY4001", "해당 카테고리 테이블을 찾을 수 없습니다."),
     CONSUMPTION_CATEGORY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "CONSUMPTION_CATEGORY4001", "해당 카테고리 타입을 찾을 수 없습니다."),
     CONSUMPTION_CATEGORY_NAME_NOT_FOUND(HttpStatus.NOT_FOUND, "CONSUMPTION_CATEGORY4002", "해당 카테고리 이름을 찾을 수 없습니다."),
+    CONSUMPTION_CATEGORY_NAME_MISSING_IN_REQUEST(HttpStatus.NOT_FOUND, "CONSUMPTION_CATEGORY4003", "요청에 누락된 소비 카테고리 항목이 있습니다. (예산에 등록된 소비 카테고리 중 일부가 요청에 포함되지 않았습니다."),
 
     // 소비 기록 에러
     CONSUMPTION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "CONSUMPTION4001", "일치하는 소비기록이 존재하지 않습니다."),


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #95 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 예산 등록/수정 시 `routineCategoryBudgets` 관련 예외 처리 추가 
  - 소비 루틴 카테고리 리스트는 소비 루틴을 등록한 적이 있는 사용자이거나, 타인의 소비 루틴을 내 예산에 반영하여 소비 루틴 카테고리가 있는 경우에만 포함하도록
- 사용자 회원가입 시, `Budget`, 기본 타입 `ConsumptionCategory`, `BudgetCategory` 테이블 생성 추가
  - 회원가입 시 예산 및기본 타입의 소비 카테고리(배달/외식, 카페 등..) 관련 데이터가 생성되도록
  - 사용자의 소비 카테고리 조회 시, 예산 등록을 하지 않은 사용자도 카테고리 목록을 조회하기 위함
- 가계부-특정 월의 일일 소비 내역 조회(커서 기반 무한스크롤)시, 다음 요청할 데이터가 없다면 `cursorId`가 null이 되도록 수정
- 가계부 달력-특정 날짜 소비 내역 조회를 List 기반 조회에서 커서 기반 스크롤 형식으로 수정

## 📌 공유 사항
X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
사용자 회원가입 시, ,기본 타입 `ConsumptionCategory`, `BudgetCategory`, `Budget` 테이블 생성 추가
<img width="1221" height="135" alt="스크린샷 2025-08-01 오전 1 59 45" src="https://github.com/user-attachments/assets/dc62f019-596b-48a0-a41b-9c6550a7ca8a" />
<img width="1234" height="146" alt="스크린샷 2025-08-01 오전 2 00 03" src="https://github.com/user-attachments/assets/17dedd96-e788-40c4-9da3-c3084606df6b" />
<img width="1300" height="41" alt="스크린샷 2025-08-01 오전 2 00 26" src="https://github.com/user-attachments/assets/e87e6e53-ad9f-46ff-adba-b33f6932e020" />  

가계부 달력-특정 날짜 소비 내역 조회 (커서 기반 무한스크롤)
<img width="483" height="509" alt="스크린샷 2025-08-01 오전 2 02 12" src="https://github.com/user-attachments/assets/be71af96-7c8b-463d-8310-e99a7107462a" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
