### PR TITLE
[#99] 🐛Fix: 소비 루틴 등록 시 새로운 카테고리 저장 오류 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -48,7 +48,6 @@ public class BudgetController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
-            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_ALREADY_EXIST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "CONSUMPTION_CATEGORY_TYPE_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_CATEGORY_NOT_ALLOWED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
@@ -93,7 +92,7 @@ public class BudgetController {
     @ApiSuccessCodeExample(resultClass = BudgetResponse.TotalConsumptionResultDTO.class)
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
-//            @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_EXIST"),
+//            @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_CONSUMPTION_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
@@ -98,10 +98,9 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
             updateCategoryBudgetsByType(request.getDefaultCategoryBudgets(), user, budget, CategoryType.DEFAULT, existingMapByType.getOrDefault(CategoryType.DEFAULT, Map.of()));
             updateCategoryBudgetsByType(request.getCustomCategoryBudgets(), user, budget, CategoryType.CUSTOM, existingMapByType.getOrDefault(CategoryType.CUSTOM, Map.of()));
 
-            // 소비 루틴 카테고리는 소비 루틴을 등로한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 가능
+            // 소비 루틴 카테고리는 타인의 소비 루틴을 내 예산에 반영하여 소비 루틴 카테고리가 생성된 경우만 가능
             if (hasRoutineCategoryBudget(request)) {
-                boolean hasRoutineData = budget.getIsFromRoutine()
-                        || consumptionCategoryRepository.existsByUserAndBudgetCategoryType(user, CategoryType.ROUTINE_CATEGORY);
+                boolean hasRoutineData = consumptionCategoryRepository.existsByUserAndBudgetCategoryType(user, CategoryType.ROUTINE_CATEGORY);
 
                 if (!hasRoutineData) {
                     throw new ErrorHandler(ErrorStatus.ROUTINE_CATEGORY_NOT_ALLOWED);
@@ -119,10 +118,9 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
             saveCategoryBudgetsByType(request.getDefaultCategoryBudgets(), user, budget, CategoryType.DEFAULT);
             saveCategoryBudgetsByType(request.getCustomCategoryBudgets(), user, budget, CategoryType.CUSTOM);
 
-            // 소비 루틴 카테고리는 소비 루틴을 등로한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 가능
+            // 소비 루틴 카테고리는 타인의 소비 루틴을 내 예산에 반영하여 소비 루틴 카테고리가 생성된 경우만 가능
             if (hasRoutineCategoryBudget(request)) {
-                boolean hasRoutineData = budget.getIsFromRoutine()
-                        || consumptionCategoryRepository.existsByUserAndBudgetCategoryType(user, CategoryType.ROUTINE_CATEGORY);
+                boolean hasRoutineData = consumptionCategoryRepository.existsByUserAndBudgetCategoryType(user, CategoryType.ROUTINE_CATEGORY);
 
                 if (!hasRoutineData) {
                     throw new ErrorHandler(ErrorStatus.ROUTINE_CATEGORY_NOT_ALLOWED);
@@ -262,42 +260,44 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
                                               CategoryType type,
                                               Map<String, BudgetCategory> existingMap) {
 
-        // 1. 각 이름-금액 쌍에 대해 저장 또는 수정 처리
-        List<BudgetCategory> toSave = nameToAmount.entrySet().stream()
-                .map(entry -> {
-                    String name = entry.getKey();
-                    Integer amount = entry.getValue();
+        // 1. 기본 타입(DEFAULT)인 경우 누락된 항목을 0원으로 보정
+        if (type == CategoryType.DEFAULT) {
+            for (String defaultName : DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES) {
+                if (!nameToAmount.containsKey(defaultName)) {
+                    nameToAmount.put(defaultName, 0);
+                }
+            }
+        }
 
-                    // 이미 존재하는 BudgetCategory가 있으면 금액만 업데이트
-                    BudgetCategory existing = existingMap.get(name);
-                    if (existing != null) {
-                        existing.updateAmount(amount);
-                        return null; // 업데이트만, 새로 저장할 건 아님
-                    }
+        // 2. 저장 또는 업데이트할 BudgetCategory 리스트 생성
+        List<BudgetCategory> toSave = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : nameToAmount.entrySet()) {
+            String name = entry.getKey();
+            Integer amount = entry.getValue();
 
-                    // 없으면 ConsumptionCategory를 찾거나 생성하고 BudgetCategory 생성
-                    ConsumptionCategory category = consumptionCategoryRepository
-                            .findByUserAndBudgetCategoryNameAndBudgetCategoryType(user, name, type)
-                            .orElseGet(() -> consumptionCategoryRepository.save(
-                                    ConsumptionCategoryConverter.toConsumptionCategory(user, name, type)
-                            ));
-                    return BudgetCategoryConverter.toBudgetCategory(budget, category, amount);
-                })
-                .filter(Objects::nonNull) // 새로 생성된 것만 저장 대상
-                .toList();
+            BudgetCategory existing = existingMap.get(name);
+            if (existing != null) {
+                existing.updateAmount(amount);
+                continue; // 업데이트 완료
+            }
 
-        // 2. 새로 생성된 BudgetCategory 저장
+            ConsumptionCategory category = consumptionCategoryRepository
+                    .findByUserAndBudgetCategoryNameAndBudgetCategoryType(user, name, type)
+                    .orElseGet(() -> consumptionCategoryRepository.save(
+                            ConsumptionCategoryConverter.toConsumptionCategory(user, name, type)
+                    ));
+
+            toSave.add(BudgetCategoryConverter.toBudgetCategory(budget, category, amount));
+        }
+
+        // 3. 새 BudgetCategory 저장
         if (!toSave.isEmpty()) {
             budgetCategoryRepository.saveAll(toSave);
         }
 
-        // 3. 삭제 대상 처리 (요청에 포함되지 않은 기존 BudgetCategory 삭제)
-        // 요청된 nameToAmount에 없는 기존 항목은 삭제 대상이 됨
-        // 단, DEFAULT 타입은 삭제 금지
-        if (type != CategoryType.DEFAULT) { // 기본 카테고리는 삭제 금지
-
-            Set<String> requestedNames = (nameToAmount != null) ? nameToAmount.keySet() : Set.of();
-
+        // 4. DEFAULT가 아닐 경우, 요청에 없는 기존 BudgetCategory 삭제
+        if (type != CategoryType.DEFAULT) {
+            Set<String> requestedNames = nameToAmount.keySet();
             List<BudgetCategory> toDelete = existingMap.entrySet().stream()
                     .filter(entry -> !requestedNames.contains(entry.getKey()))
                     .map(Map.Entry::getValue)
@@ -308,26 +308,22 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
                         budget.getId(), type.name(),
                         toDelete.stream().map(BudgetCategory::getId).toList());
 
-                // 먼저 BudgetCategory 삭제
                 budgetCategoryRepository.deleteAllInBatch(toDelete);
 
-                // BudgetCategory 삭제 후 연결된 ConsumptionCategory도 고아이면 삭제
+                // 연관된 ConsumptionCategory도 고아이면 삭제
                 List<Long> categoryIds = toDelete.stream()
                         .map(bc -> bc.getConsumptionCategory().getId())
                         .distinct()
                         .toList();
 
-                // 고아 상태인지 확인 후 삭제
-                List<ConsumptionCategory> consumptionToDelete = consumptionCategoryRepository
-                        .findAllById(categoryIds)
-                        .stream()
+                List<ConsumptionCategory> orphaned = consumptionCategoryRepository.findAllById(categoryIds).stream()
                         .filter(cat -> budgetCategoryRepository.countByConsumptionCategory(cat) == 0)
                         .toList();
 
-                if (!consumptionToDelete.isEmpty()) {
+                if (!orphaned.isEmpty()) {
                     log.info("[카테고리 삭제] 삭제 대상(ConsumptionCategory)={}",
-                            consumptionToDelete.stream().map(ConsumptionCategory::getId).toList());
-                    consumptionCategoryRepository.deleteAllInBatch(consumptionToDelete);
+                            orphaned.stream().map(ConsumptionCategory::getId).toList());
+                    consumptionCategoryRepository.deleteAllInBatch(orphaned);
                 }
             }
         }

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -106,16 +106,14 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
         LocalDateTime startOfMonth = LocalDate.of(year, month, 1).atStartOfDay();
         LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
 
-        // 해당 월의 총 소비 금액 조회, 데이터가 없다면 생성
+        // 해당 월의 총 소비 금액 조회
         TotalConsumption totalConsumption = totalConsumptionRepository
                 .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseGet(() -> {
-                    TotalConsumption newConsumption = TotalConsumptionConverter.toTotalConsumption(user);
-                    return totalConsumptionRepository.save(newConsumption);
-                });
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_EXIST));
 
         // 해당 월의 예산 조회
         Budget budget = budgetRepository.findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
+                .filter(b -> b.getBudgetTotal() > 0)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_EXIST));
 
         Long budgetId = budget.getId();

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -47,6 +47,7 @@ public class RoutineController {
             summary = "소비 루틴 등록 API",
             description = "해당 API는 소비 루틴을 등록하는 기능을 제공합니다. 예산 ID는 Path Variable로 전달하며, 카테고리, 금액, 설명 등의 루틴 정보는 RequestBody로 전달합니다. " +
                     "먼저 '한 달 예산 내역 조회 API'를 통해 본인의 예산 목록을 확인한 후, 해당 예산에 포함된 모든 소비 카테고리를 기준으로 요청 데이터를 구성해 주세요. " +
+                    "기존 예산에 저장되어 있는 카테고리 이외에 새로운 카테고리와 금액을 등록할 경우, 요청 데이터에 포함해주세요." +
                     "카테고리별 예산 금액이 기존과 다를 경우, 수정된 금액으로 요청하시면 해당 금액이 반영됩니다."
     )
     @ApiSuccessCodeExample(resultClass = RoutineResponse.RoutineCreateResultDTO.class)

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -4,6 +4,8 @@ import com.server.money_touch.domain.budget.entity.Budget;
 import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
 import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
 import com.server.money_touch.domain.routine.converter.RoutineConverter;
 import com.server.money_touch.domain.routine.converter.RoutineHashtagConverter;
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
@@ -16,18 +18,16 @@ import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.server.money_touch.global.apiPayload.code.status.ErrorStatus.*;
 
@@ -43,6 +43,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
     private final UserRepository userRepository;
     private final BudgetRepository budgetRepository;
     private final BudgetCategoryRepository budgetCategoryRepository;
+    private final ConsumptionCategoryRepository consumptionCategoryRepository;
 
     // 소비 루틴 등록
     @Transactional
@@ -81,7 +82,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         Map<String, Integer> requestMap = request.getBudgetList().stream()
                 .collect(Collectors.toMap(RoutineRequest.CategoryBudgetDTO::getCategoryName, RoutineRequest.CategoryBudgetDTO::getAmount));
 
-        // 6. 해당 예산에 연결된 예산 카테고리 + 소비 카테고리 조회 (JOIN FETCH 필요)
+        // 6. 해당 예산에 연결된 예산 카테고리 + 소비 카테고리 조회
         List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllByBudgetIdWithCategory(budgetId);
 
         // 7. categoryName → BudgetCategory 맵핑
@@ -91,18 +92,38 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
                         Function.identity()
                 ));
 
-        // 8. 요청 기준으로 비교 후 금액 수정
-        requestMap.forEach((categoryName, amount) -> {
-            BudgetCategory category = budgetCategoryMap.get(categoryName);
-            if (category == null) {
-                throw new ErrorHandler(CONSUMPTION_CATEGORY_NAME_NOT_FOUND);
-            }
-            if (!category.getBudgetCategoryMoney().equals(amount)) {
-                category.updateAmount(amount);
-            }
-        });
+        // 8. 요청 기준으로 비교 후 금액 수정 or 새로 생성
+        for (Map.Entry<String, Integer> entry : requestMap.entrySet()) {
+            String categoryName = entry.getKey();
+            Integer amount = entry.getValue();
 
-        // 8-1. 요청에 포함되지 않은 소비 카테고리 존재 시 예외 처리 (Stream 방식)
+            BudgetCategory category = budgetCategoryMap.get(categoryName);
+
+            if (category != null) {
+                if (!category.getBudgetCategoryMoney().equals(amount)) {
+                    category.updateAmount(amount);
+                }
+            } else {
+                // 존재하지 않는 경우 CUSTOM 타입 소비 카테고리 및 예산 카테고리 생성
+                ConsumptionCategory newCategory = ConsumptionCategory.builder()
+                        .budgetCategoryName(categoryName)
+                        .budgetCategoryType(CategoryType.CUSTOM)
+                        .user(user)
+                        .build();
+
+                ConsumptionCategory savedCategory = consumptionCategoryRepository.save(newCategory);
+
+                BudgetCategory newBudgetCategory = BudgetCategory.builder()
+                        .budget(budget)
+                        .consumptionCategory(savedCategory)
+                        .budgetCategoryMoney(amount)
+                        .build();
+
+                budgetCategoryRepository.save(newBudgetCategory);
+            }
+        }
+
+        // 8-1. 요청에 포함되지 않은 소비 카테고리 존재 시 예외 처리
         budgetCategoryMap.keySet().stream()
                 .filter(categoryName -> !requestMap.containsKey(categoryName))
                 .findFirst()
@@ -122,7 +143,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             routineHashtagRepository.saveAll(hashtags);
         }
 
-        // 11. 결과 DTO 변환 후 반환
+        // 11. 결과 DTO 반환
         Long routineId = routine.getId();
         log.info("소비 루틴 등록 완료 - userId: {}, routineId: {}", userId, routineId);
         return RoutineConverter.toRoutineCreateResultDTO(routineId);

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -55,6 +55,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 고정비 관련 에러
     FIXED_CONSUMPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FIXED_CONSUMPTION4001", "아이디와 일치하는 고정비가 없습니다."),
 
+    // 총 소비 관련 에러
+    TOTAL_CONSUMPTION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "TOTAL_CONSUMPTION5001", "총 소비 데이터가 존재하지 않습니다. 관리자에게 문의 바랍니다."),
+
     // 소비 루틴 관련 에러
     ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE4001", "아이디와 일치하는 소비 루틴이 없습니다."),
     ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE4002", "한 달 소비 루틴 등록 횟수를 초과하였습니다."),


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #99 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 소비 루틴 등록 시 예산에 포함되지 않은 새로운 카테고리를 저장 할 때, 에러를 반환하는게 아닌 새로운 `ConsumptionCategory`(커스텀 내 소비 카테고리 타입), `BudgetCategory` 데이터가 생성되도록
  - `CUSTOM` 카테고리는 예산&소비 루틴 등록 시 생성한 카테고리, `ROUTINE` 카테고리는 타인의 소비 루틴을 가져왔을 때 생성되는 카테고리로 고정할 예정

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  수정하다가 방금 깨달은건데, 생각해보니 소비 루틴을 등록하면 관련된 금액은 수정되지 않는게 맞는것 같은데, 금액 데이터들이예산과 관련되도록 설계해놔서 예산을 수정하니 소비 루틴에 관련된 금액도 수정되는 오류를 발견했습니다.. 소비 루틴 관련 금액 테이블을 따로 두는게 맞는 것 같은데 이 부분은 좀 더 고민해 보겠습니다ㅠ


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="713" height="644" alt="스크린샷 2025-08-01 오후 5 24 05" src="https://github.com/user-attachments/assets/fb18004d-2338-4074-bab4-cda0f228ec13" />
<img width="1219" height="193" alt="스크린샷 2025-08-01 오후 5 28 05" src="https://github.com/user-attachments/assets/4493cb8d-0a41-47ed-ae5a-3e9bf37d35a8" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
