### PR TITLE
🐛Fix: 예산 아이디 및 총 소비 금액 조회 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -87,7 +87,7 @@ public class BudgetController {
     @Operation(
             summary = "예산 아이디 및 한 달 총 소비 금액 조회 API",
             description = "한 달 예산을 기준으로 예산 아이디 및 현재까지의 총 소비 금액을 반환합니다. " +
-                    "이번 달 등록된 예산이 없는 경우, totalConsumptionAmount는 0원을 반환합니다."
+                    "이번 달 등록된 예산이 없는 경우, totalConsumptionAmount는 0원, budetId는 null을 반환합니다."
     )
     @ApiSuccessCodeExample(resultClass = BudgetResponse.TotalConsumptionResultDTO.class)
     @ApiErrorCodeExamples({

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
@@ -3,6 +3,8 @@ package com.server.money_touch.domain.budget.repository.budget;
 import com.server.money_touch.domain.budget.entity.Budget;
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -10,4 +12,12 @@ import java.util.Optional;
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
     Optional<Budget> findByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
     Optional<Budget> findByUserIdAndCreatedMonth(Long userId, String createdMonth);
+
+    @Query("SELECT b FROM Budget b WHERE b.user = :user " +
+            "AND b.createdAt BETWEEN :start AND :end " +
+            "AND b.createdAt = b.updatedAt")
+    Optional<Budget> findByUserAndCreatedAtBetweenAndCreatedEqualsUpdated(@Param("user") User user,
+                                                                          @Param("start") LocalDateTime start,
+                                                                          @Param("end") LocalDateTime end);
+
 }

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -106,18 +106,20 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
         LocalDateTime startOfMonth = LocalDate.of(year, month, 1).atStartOfDay();
         LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
 
-        // 해당 월의 총 소비 금액 조회
+        // 총 소비 금액 조회 (없으면 0으로 처리)
         TotalConsumption totalConsumption = totalConsumptionRepository
                 .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_EXIST));
+                .orElse(null);
 
-        // 해당 월의 예산 조회
+        int totalAmount = (totalConsumption != null) ? totalConsumption.getTotalConsumptionAmount() : 0;
+
+        // 예산 조회 (없으면 budgetId = null)
         Budget budget = budgetRepository.findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
                 .filter(b -> b.getBudgetTotal() > 0)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_EXIST));
+                .orElse(null);
 
-        Long budgetId = budget.getId();
+        Long budgetId = (budget != null) ? budget.getId() : null;
         log.info("예산 아이디 및 총 소비 금액 조회 - userId: {}, budgetId: {}", userId, budgetId);
-        return BudgetConverter.toTotalConsumptionResultDto(budgetId, totalConsumption.getTotalConsumptionAmount());
+        return BudgetConverter.toTotalConsumptionResultDto(budgetId, totalAmount);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -114,7 +114,9 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
         int totalAmount = (totalConsumption != null) ? totalConsumption.getTotalConsumptionAmount() : 0;
 
         // 예산 조회 (없으면 budgetId = null)
-        Budget budget = budgetRepository.findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
+        // 회원가입 및 1일에 데이터가 생성되기 때문에 createdAt과 updatedAt이 같으면 아직 사용자가 직접 등록하지 않은 예산으로 간주
+        Budget budget = budgetRepository
+                .findByUserAndCreatedAtBetweenAndCreatedEqualsUpdated(user, startOfMonth, endOfMonth)
                 .filter(b -> b.getBudgetTotal() > 0)
                 .orElse(null);
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
 - #99

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 한 달 예산 기준 총 소비 사용 금액 조회에서 이번 달 등록된 예산이 없는 경우, totalConsumptionAmount는 0원, bugetId는 null을 반환하도록 수정

## 📌 공유 사항
X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
