### PR TITLE
[#109] ✨Feat: 타인의 소비 루틴 가져오기 관련 구현 및 소비 루틴 상세 조회 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/server/money_touch/domain/budget/controller/BudgetController.java
@@ -53,12 +53,17 @@ public class BudgetController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
+    @Parameters({
+            @Parameter(name = "year", description = "등록하려는 연도", example = "2025", required = true),
+            @Parameter(name = "month", description = "등록하려는 월", example = "7", required = true),
+    })
     @PostMapping()
-    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
+    public ApiResponse<BudgetResponse.BudgetCreateResultDTO> postBudget(@RequestParam Integer year, @RequestParam Integer month,
+                                                                        @Valid @RequestBody BudgetRequest.BudgetCreateDTO request,
                                                                         HttpServletRequest servletRequest) {
 
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
-        BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(userId, request);
+        BudgetResponse.BudgetCreateResultDTO response = budgetCommandService.saveOrUpdateBudgetWithCategories(userId, year, month, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/budget/converter/budget/BudgetConverter.java
+++ b/src/main/java/com/server/money_touch/domain/budget/converter/budget/BudgetConverter.java
@@ -12,12 +12,12 @@ import java.util.List;
 public class BudgetConverter {
 
     // BudgetCreateDTO → Budget Entity 변환
-    public static Budget toBudgetEntity(User user, Integer budgetTotal) {
+    public static Budget toBudgetEntity(User user, Integer budgetTotal, String createdMonth) {
         String currentMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
         return Budget.builder()
                 .user(user)
                 .budgetTotal(budgetTotal)
-                .createdMonth(currentMonth)
+                .createdMonth(createdMonth)
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetRequest.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetRequest.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.budget.dto;
 
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -50,6 +51,9 @@ public class BudgetRequest {
         @Schema(description = "카테고리별 예산 금액", example = "100000")
         @NotNull(message = "카테고리 금액은 필수입니다.")
         private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "DEFAULT")
+        private CategoryType categoryType;
     }
 
     @Getter
@@ -66,6 +70,9 @@ public class BudgetRequest {
         @Schema(description = "카테고리별 예산 금액", example = "150000")
         @NotNull(message = "카테고리 금액은 필수입니다.")
         private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "CUSTOM")
+        private CategoryType categoryType;
     }
 
     @Getter
@@ -82,5 +89,8 @@ public class BudgetRequest {
         @Schema(description = "카테고리별 예산 금액", example = "100000")
         @NotNull(message = "카테고리 금액은 필수입니다.")
         private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "ROUTINE_CATEGORY")
+        private CategoryType categoryType;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.budget.dto;
 
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -61,6 +62,9 @@ public class BudgetResponse {
 
         @Schema(description = "카테고리별 예산 금액", example = "200000")
         private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
+        private CategoryType categoryType;
     }
 
     @Builder
@@ -74,6 +78,9 @@ public class BudgetResponse {
 
         @Schema(description = "카테고리별 예산 금액", example = "150000")
         private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
+        private CategoryType categoryType;
     }
 
     @Builder
@@ -87,5 +94,8 @@ public class BudgetResponse {
 
         @Schema(description = "카테고리별 예산 금액", example = "150000")
         private Integer amount;
+
+        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
+        private CategoryType categoryType;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
@@ -11,15 +11,20 @@ import java.util.Optional;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
     Optional<Budget> findByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
-    Optional<Budget> findByUserIdAndCreatedMonth(Long userId, String createdMonth);
 
-    @Query("SELECT b FROM Budget b WHERE b.user = :user " +
-            "AND b.createdAt BETWEEN :start AND :end " +
-            "AND b.createdAt = b.updatedAt")
-    Optional<Budget> findByUserAndCreatedAtBetweenAndCreatedEqualsUpdated(@Param("user") User user,
-                                                                          @Param("start") LocalDateTime start,
-                                                                          @Param("end") LocalDateTime end);
+    Optional<Budget> findByUserIdAndCreatedMonth(Long userId, String createdMonth);
 
     Optional<Budget> findByUserAndCreatedMonth(User user, String createdMonth);
 
+    @Query(value = """
+    SELECT * FROM budget b
+    WHERE b.user_id = :userId
+    AND b.created_at BETWEEN :start AND :end
+    AND TIMESTAMPDIFF(SECOND, b.created_at, b.updated_at) != 0
+    AND b.budget_total > 0
+    LIMIT 1
+    """, nativeQuery = true)
+    Optional<Budget> findRegisteredBudgetInMonthNative(@Param("userId") Long userId,
+                                                       @Param("start") LocalDateTime start,
+                                                       @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
@@ -20,4 +20,6 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
                                                                           @Param("start") LocalDateTime start,
                                                                           @Param("end") LocalDateTime end);
 
+    Optional<Budget> findByUserAndCreatedMonth(User user, String createdMonth);
+
 }

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budgetCategory/BudgetCategoryRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budgetCategory/BudgetCategoryRepository.java
@@ -34,5 +34,10 @@ public interface BudgetCategoryRepository extends JpaRepository<BudgetCategory, 
     // budgetId 기준으로 BudgetCategory를 조회하면서 연관된 ConsumptionCategory도 JOIN FETCH로 한 번에 가져오도록
     @Query("SELECT bc FROM BudgetCategory bc JOIN FETCH bc.consumptionCategory WHERE bc.budget.id = :budgetId")
     List<BudgetCategory> findAllByBudgetIdWithCategory(@Param("budgetId") Long budgetId);
+
+    List<BudgetCategory> findByBudget(Budget budget);
+
+    @Query("SELECT bc FROM BudgetCategory bc JOIN FETCH bc.consumptionCategory WHERE bc.budget = :budget")
+    List<BudgetCategory> findByBudgetWithConsumptionCategory(@Param("budget") Budget budget);
 }
 

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandService.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public interface BudgetCommandService {
     // 예산 수정
-    BudgetResponse.BudgetCreateResultDTO saveOrUpdateBudgetWithCategories(@ExistUser Long userId, BudgetRequest.BudgetCreateDTO request);
+    BudgetResponse.BudgetCreateResultDTO saveOrUpdateBudgetWithCategories(@ExistUser Long userId, Integer year, Integer month, BudgetRequest.BudgetCreateDTO request);
 
     // 기본 & 사용자 정의 & 소비 루틴 카테고리별 예산 수정
     void updateCategoryBudgetsByType(List<? extends Object> requestList,

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
@@ -43,17 +43,14 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
     // 예산 등록 또는 수정
     @Transactional
     @Override
-    public BudgetResponse.BudgetCreateResultDTO saveOrUpdateBudgetWithCategories(Long userId, BudgetRequest.BudgetCreateDTO request) {
+    public BudgetResponse.BudgetCreateResultDTO saveOrUpdateBudgetWithCategories(Long userId, Integer year, Integer month, BudgetRequest.BudgetCreateDTO request) {
         // 1. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 2. 이번 달 기준 예산 조회
-        YearMonth now = YearMonth.now();
-        LocalDateTime start = now.atDay(1).atStartOfDay(); // 월 시작 00:00:00
-        LocalDateTime end = now.atEndOfMonth().atTime(LocalTime.MAX);
-
-        Optional<Budget> optionalBudget = budgetRepository.findByUserAndCreatedAtBetween(user, start, end);
+        // 2. 파라미터 기준 예산 조회 (예: 2025-07)
+        String createdMonth = String.format("%d-%02d", year, month); // createdMonth 문자열로 변환 ("2025-07")
+        Optional<Budget> optionalBudget = budgetRepository.findByUserAndCreatedMonth(user, createdMonth);
 
         // 3. 카테고리 총합 계산
         int totalCategoryBudget = Stream.of(
@@ -105,14 +102,13 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
                 if (!hasRoutineData) {
                     throw new ErrorHandler(ErrorStatus.ROUTINE_CATEGORY_NOT_ALLOWED);
                 }
-
-                updateCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY, existingMapByType.getOrDefault(CategoryType.ROUTINE_CATEGORY, Map.of()));
             }
+            updateCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY, existingMapByType.getOrDefault(CategoryType.ROUTINE_CATEGORY, Map.of()));
 
             log.info("예산 수정 완료 - userId: {}, budgetId: {}", userId, budget.getId());
         } else {
             // 5-B. 예산 없음: 새로 등록
-            budget = BudgetConverter.toBudgetEntity(user, request.getTotalBudget());
+            budget = BudgetConverter.toBudgetEntity(user, request.getTotalBudget(), createdMonth);
             budgetRepository.save(budget);
 
             saveCategoryBudgetsByType(request.getDefaultCategoryBudgets(), user, budget, CategoryType.DEFAULT);
@@ -125,8 +121,7 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
                 if (!hasRoutineData) {
                     throw new ErrorHandler(ErrorStatus.ROUTINE_CATEGORY_NOT_ALLOWED);
                 }
-
-                saveCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY);
+//                saveCategoryBudgetsByType(request.getRoutineCategoryBudgets(), user, budget, CategoryType.ROUTINE_CATEGORY);
             }
 
             log.info("예산 등록 완료 - userId: {}, budgetId: {}", user.getId(), budget.getId());
@@ -344,7 +339,8 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
         }
 
         // 없다면 새로 생성
-        Budget newBudget = BudgetConverter.toBudgetEntity(user, 0);
+        String createdMonth = String.format("%d-%02d", now.getYear(), now.getMonthValue()); // ← 수정된 부분
+        Budget newBudget = BudgetConverter.toBudgetEntity(user, 0, createdMonth);
 
         return budgetRepository.save(newBudget);
     }

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -118,9 +118,7 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
 
         // 예산 조회 (없으면 budgetId = null)
         // 회원가입 및 1일에 데이터가 생성되기 때문에 createdAt과 updatedAt이 같으면 아직 사용자가 직접 등록하지 않은 예산으로 간주
-        Budget budget = budgetRepository
-                .findByUserAndCreatedAtBetweenAndCreatedEqualsUpdated(user, startOfMonth, endOfMonth)
-                .filter(b -> b.getBudgetTotal() > 0)
+        Budget budget = budgetRepository.findRegisteredBudgetInMonthNative(userId, startOfMonth, endOfMonth)
                 .orElse(null);
 
         Long budgetId = (budget != null) ? budget.getId() : null;

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -65,6 +65,7 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
                         bc -> BudgetResponse.DefaultCategoryBudgetResponse.builder()
                                 .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
                                 .amount(bc.getBudgetCategoryMoney())
+                                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
                                 .build());
 
         List<BudgetResponse.CustomCategoryBudgetResponse> customCategories =
@@ -72,6 +73,7 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
                         bc -> BudgetResponse.CustomCategoryBudgetResponse.builder()
                                 .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
                                 .amount(bc.getBudgetCategoryMoney())
+                                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
                                 .build());
 
         List<BudgetResponse.RoutineCategoryBudgetResponse> routineCategories =
@@ -79,6 +81,7 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
                         bc -> BudgetResponse.RoutineCategoryBudgetResponse.builder()
                                 .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
                                 .amount(bc.getBudgetCategoryMoney())
+                                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
                                 .build());
 
         // 4. 응답 DTO 구성

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
@@ -28,4 +28,8 @@ public class ConsumptionCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public void updateCategoryType(CategoryType newType) {
+        this.budgetCategoryType = newType;
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -175,25 +175,27 @@ public class RoutineController {
         return ApiResponse.onSuccess(response);
     }
 
-    // 소비 루틴 예산 반영 전 수정/추가
+    // 소비 루틴 예산 반영 전 수정/추가(미리 보기)_
     @Operation(
-            summary = "소비 루틴 예산 반영 전 수정/추가 API",
-            description = "내 예산에 반영-> 네 를 클릭하면 보여주는 api 입니다."+
-                    "사용자가 갖고 있는 기존 카테고리는 '카테고리별 예산', 새로운 카테고리는 '소비 루틴 카테고리' 보여줍니다."
+            summary = "소비 루틴 예산 반영 전 수정/추가(미리보기) API",
+            description = "해당 API는 소비 루틴을 예산에 반영하기 전에, 적용 시 변경될 카테고리별 금액을 미리 확인할 수 있도록 합니다. " +
+                    "'내 예산에 반영 → 네'를 선택하기 전, 기존 예산에 포함된 카테고리는 '카테고리별 예산'으로, 새롭게 추가되는 카테고리는 '소비 루틴 카테고리'로 구분하여 보여줍니다."
     )
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_ALREADY_APPLIED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @Parameters({
-            @Parameter(name = "routineId", description = "조회하려는 소비 루틴 아이디", example = "1", required = true),
+            @Parameter(name = "routineId", description = "가져오려는 소비 루틴 아이디", example = "1", required = true),
     })
     @GetMapping("/list/{routineId}/apply-info")
-    public ApiResponse<RoutineResponse.ApplyRoutineInfoDTO> getRoutineApplyInfo(@PathVariable Long routineId){
+    public ApiResponse<RoutineResponse.ApplyRoutineInfoDTO> getRoutineApplyInfo(@PathVariable Long routineId, HttpServletRequest servletRequest) {
 
-        RoutineResponse.ApplyRoutineInfoDTO response = RoutineResponse.ApplyRoutineInfoDTO.builder().build();
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        RoutineResponse.ApplyRoutineInfoDTO response = routineQueryService.getRoutineApplyInfo(userId, routineId);
         return ApiResponse.onSuccess(response);
 
     }

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -202,31 +202,36 @@ public class RoutineController {
 
     // 소비 루틴 예산 반영
     @Operation(
-            summary = "소비 루틴 예산 반영 API",
-            description = "실제 예산에 반영. 새로운 카테고리는 ROUTINE_CATEGORY로 추가"
+            summary = "타인의 소비 루틴을 내 예산에 반영 API",
+            description = "해당 API는 사용자가 직접 예산을 등록하거나 수정하는 것이 아닌, 타인의 소비 루틴을 자신의 예산에 반영할 때 사용합니다. " +
+                    "반영 전에는 '소비 루틴 예산 미리보기 API'를 통해 카테고리 관련 요청 데이터를 구성합니다." +
+                    "필요 시 금액을 수정하거나 항목을 추가할 수 있습니다. " +
+                    "만약 새로운 소비 카테고리를 추가한 경우에는 customCategoryBudgets에 타입을 CUSTOM으로 지정하여 포함시켜야 합니다."
     )
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "BUDGET_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_EXCEEDED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "TOTAL_BUDGET_TOO_LOW"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "ROUTINE_ALREADY_APPLIED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
     })
     @Parameters({
-            @Parameter(name = "routineId", description = "소비 루틴 ID", required = true, example = "1")
+            @Parameter(name = "budgetId", description = "현재 월의 예산 아이디", example = "1", required = true),
+            @Parameter(name = "routineId", description = "가져오려는 타인의 소비 루틴 ID", example = "1", required = true)
     })
-    @PutMapping("/list/{routineId}/apply")
-    public ApiResponse<RoutineResponse.ApplyRoutineSuccessDTO> applyRoutineToBudget(
-            @PathVariable Long routineId,
-            @Valid @RequestBody RoutineRequest.ApplyRoutineBudgetDTO request
+    @PatchMapping("/list/{routineId}/apply")
+    public ApiResponse<String> applyRoutineToBudget(
+            @RequestParam Long budgetId,
+            @RequestParam Long routineId,
+            @Valid @RequestBody RoutineRequest.ApplyRoutineBudgetDTO request,
+            HttpServletRequest servletRequest
     ){
-
-        RoutineResponse.ApplyRoutineSuccessDTO response = RoutineResponse.ApplyRoutineSuccessDTO.builder()
-                .message("예산에 성공적으로 반영되었습니다.")
-                .build();
-
-        return ApiResponse.onSuccess(response);
+        Long userId = authUtil.getUserIdFromRequest(servletRequest);
+        routineCommandService.applyRoutineToBudget(userId, budgetId, routineId, request);
+        return ApiResponse.onSuccess("예산에 성공적으로 반영되었습니다.");
     }
 
     // 소비 루틴 검색 (커서 기반 무한 스크롤)

--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
@@ -1,6 +1,8 @@
 package com.server.money_touch.domain.routine.converter;
 
 import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.entity.BudgetCategory;
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.domain.routine.entity.Routine;
@@ -63,6 +65,39 @@ public class RoutineConverter {
                 .isLast(slice.isLast())
                 .hasNext(slice.hasNext())
                 .nextCursorId(slice.hasNext() ? routineList.get(routineList.size() - 1).getRoutineId() : null)
+                .build();
+    }
+
+    // 통합 카테고리 DTO 생성 메서드
+    public static RoutineResponse.ApplyCategoryBudgetDTO toCategoryDTO(String name, int amount, CategoryType type) {
+        return RoutineResponse.ApplyCategoryBudgetDTO.builder()
+                .categoryName(name)
+                .amount(amount)
+                .categoryType(type)
+                .build();
+    }
+
+    // 루틴 전용 DTO 변환
+    public static RoutineResponse.ApplyCategoryBudgetDTO toRoutineCategoryDTO(BudgetCategory rc) {
+        return toCategoryDTO(
+                rc.getConsumptionCategory().getBudgetCategoryName(),
+                rc.getBudgetCategoryMoney(),
+                CategoryType.ROUTINE_CATEGORY
+        );
+    }
+
+    // ApplyRoutineInfoDTO 생성
+    public static RoutineResponse.ApplyRoutineInfoDTO toApplyRoutineInfoDTO(
+            int totalBudget,
+            List<RoutineResponse.ApplyCategoryBudgetDTO> defaultCategoryBudgets,
+            List<RoutineResponse.ApplyCategoryBudgetDTO> customCategoryBudgets,
+            List<RoutineResponse.ApplyCategoryBudgetDTO> routineCategoryBudgets
+    ) {
+        return RoutineResponse.ApplyRoutineInfoDTO.builder()
+                .totalBudget(totalBudget)
+                .defaultCategoryBudgets(defaultCategoryBudgets)
+                .customCategoryBudgets(customCategoryBudgets)
+                .routineCategoryBudgets(routineCategoryBudgets)
                 .build();
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineRequest.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.routine.dto;
 
+import com.server.money_touch.domain.budget.dto.BudgetRequest;
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -94,16 +95,76 @@ public class RoutineRequest {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "소비 루틴 예산 반영 요청 DTO")
+    @Schema(
+            description = "소비 루틴 예산 반영 요청 DTO",
+            example = "{\n" +
+                    "  \"totalBudget\": 1000000,\n" +
+                    "  \"defaultCategoryBudgets\": [\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"배달/외식\",\n" +
+                    "      \"amount\": 150000,\n" +
+                    "      \"categoryType\": \"DEFAULT\"\n" +
+                    "    },\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"교통\",\n" +
+                    "      \"amount\": 100000,\n" +
+                    "      \"categoryType\": \"DEFAULT\"\n" +
+                    "    },\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"패션/쇼핑\",\n" +
+                    "      \"amount\": 100000,\n" +
+                    "      \"categoryType\": \"DEFAULT\"\n" +
+                    "    },\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"카페\",\n" +
+                    "      \"amount\": 0,\n" +
+                    "      \"categoryType\": \"DEFAULT\"\n" +
+                    "    },\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"기타\",\n" +
+                    "      \"amount\": 0,\n" +
+                    "      \"categoryType\": \"DEFAULT\"\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"customCategoryBudgets\": [\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"데이트\",\n" +
+                    "      \"amount\": 300000,\n" +
+                    "      \"categoryType\": \"CUSTOM\"\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"routineCategoryBudgets\": [\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"교육비\",\n" +
+                    "      \"amount\": 250000,\n" +
+                    "      \"categoryType\": \"ROUTINE_CATEGORY\"\n" +
+                    "    },\n" +
+                    "    {\n" +
+                    "      \"categoryName\": \"술/유흥\",\n" +
+                    "      \"amount\": 100000,\n" +
+                    "      \"categoryType\": \"ROUTINE_CATEGORY\"\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}"
+    )
     public static class ApplyRoutineBudgetDTO {
 
-        @Schema(description = "수정된 전체 예산", example = "500000")
-        private Integer budgetTotal;
+        @Schema(description = "전체 예산", example = "600000")
+        @NotNull(message = "전체 예산은 필수 입력 항목입니다.")
+        private Integer totalBudget;
 
-        @Schema(description = "반영할 카테고리 예산 목록 (기존+소비루틴 모두 합침)")
-        @NotNull
+        @Schema(description = "기본 카테고리별 예산 목록")
+        @NotNull(message = "기본 카테고리 예산 목록은 비어 있을 수 없습니다.")
         @Valid
-        private List<RoutineRequest.ApplyCategoryBudgetDTO> categoryBudgets;
+        private List<ApplyCategoryBudgetDTO> defaultCategoryBudgets;
+
+        @Schema(description = "내 카테고리별 예산 목록")
+        @Valid
+        private List<ApplyCategoryBudgetDTO> customCategoryBudgets;
+
+        @Schema(description = "소비 루틴 카테고리 예산 목록")
+        @Valid
+        private List<ApplyCategoryBudgetDTO> routineCategoryBudgets;
     }
 
     @Getter
@@ -114,9 +175,11 @@ public class RoutineRequest {
     public static class ApplyCategoryBudgetDTO {
 
         @Schema(description = "카테고리명", example = "배달/외식")
+        @NotNull(message = "카테고리 이름은 필수입니다.")
         private String categoryName;
 
-        @Schema(description = "카테고리 금액", example = "100000")
+        @Schema(description = "카테고리별 예산 금액", example = "100000")
+        @NotNull(message = "카테고리 금액은 필수입니다.")
         private Integer amount;
 
         @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")

--- a/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/server/money_touch/domain/routine/dto/RoutineResponse.java
@@ -227,12 +227,14 @@ public class RoutineResponse {
         @Schema(description = "총 예산", example = "500000")
         private Integer totalBudget;
 
-        @Schema(description = "기존 카테고리별 예산 목록")
-        private List<ApplyCategoryBudgetDTO> categoryBudgets;
+        @Schema(description = "기본 타입의 카테고리별 예산 목록")
+        private List<ApplyCategoryBudgetDTO> defaultCategoryBudgets;
+
+        @Schema(description = "새로운 내 소비 카테고리별 예산 목록")
+        private List<ApplyCategoryBudgetDTO> customCategoryBudgets;
 
         @Schema(description = "새로운 소비 루틴 카테고리별 예산 목록")
         private List<ApplyCategoryBudgetDTO> routineCategoryBudgets;
-
     }
 
     @Getter

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -18,8 +18,8 @@ public class Routine extends BaseEntity {
     @Column(nullable = false)
     private String routineImageUrl;
 
-//    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
-//    private Integer routineTotalAmount; // 소비 루틴 총 금액
+    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
+    private Integer routineTotalAmount; // 소비 루틴 총 금액
 
     // 소비루틴-예산 다대일
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -18,6 +18,9 @@ public class Routine extends BaseEntity {
     @Column(nullable = false)
     private String routineImageUrl;
 
+//    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
+//    private Integer routineTotalAmount; // 소비 루틴 총 금액
+
     // 소비루틴-예산 다대일
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "budget_id")

--- a/src/main/java/com/server/money_touch/domain/routine/entity/RoutineAmount.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/RoutineAmount.java
@@ -1,0 +1,30 @@
+//package com.server.money_touch.domain.routine.entity;
+//
+//import com.server.money_touch.domain.budget.enums.CategoryType;
+//import com.server.money_touch.global.apiPayload.code.BaseEntity;
+//import jakarta.persistence.*;
+//import lombok.*;
+//
+//@Getter
+//@Builder
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@AllArgsConstructor
+//@Entity
+//public class RoutineAmount extends BaseEntity {
+//    // 카테고리 이름: 술/유흥, 데이틑 등
+//    @Column(length = 8, nullable = false)
+//    private String categoryName;
+//
+////    // 카테고리 타입: 소비 루틴 카테고리?
+////    @Enumerated(EnumType.STRING)
+////    @Column(nullable = false)
+////    private CategoryType categoryType;
+//
+//    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
+//    private Integer amount; // 금액
+//
+//    // 소비 루틴 금액-소비루틴 다대일
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "routine_id")
+//    private Routine routine;
+//}

--- a/src/main/java/com/server/money_touch/domain/routine/entity/RoutineAmount.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/RoutineAmount.java
@@ -1,30 +1,30 @@
-//package com.server.money_touch.domain.routine.entity;
-//
-//import com.server.money_touch.domain.budget.enums.CategoryType;
-//import com.server.money_touch.global.apiPayload.code.BaseEntity;
-//import jakarta.persistence.*;
-//import lombok.*;
-//
-//@Getter
-//@Builder
-//@NoArgsConstructor(access = AccessLevel.PROTECTED)
-//@AllArgsConstructor
-//@Entity
-//public class RoutineAmount extends BaseEntity {
-//    // 카테고리 이름: 술/유흥, 데이틑 등
-//    @Column(length = 8, nullable = false)
-//    private String categoryName;
-//
-////    // 카테고리 타입: 소비 루틴 카테고리?
-////    @Enumerated(EnumType.STRING)
-////    @Column(nullable = false)
-////    private CategoryType categoryType;
-//
-//    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
-//    private Integer amount; // 금액
-//
-//    // 소비 루틴 금액-소비루틴 다대일
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "routine_id")
-//    private Routine routine;
-//}
+package com.server.money_touch.domain.routine.entity;
+
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class RoutineAmount extends BaseEntity {
+    // 카테고리 이름: 술/유흥, 데이틑 등
+    @Column(length = 8, nullable = false)
+    private String categoryName;
+
+//    // 카테고리 타입: 소비 루틴 카테고리?
+//    @Enumerated(EnumType.STRING)
+//    @Column(nullable = false)
+//    private CategoryType categoryType;
+
+    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
+    private Integer amount; // 금액
+
+    // 소비 루틴 금액-소비루틴 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id")
+    private Routine routine;
+}

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineAmountRepository.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineAmountRepository.java
@@ -1,0 +1,14 @@
+package com.server.money_touch.domain.routine.repository.routine;
+
+import com.server.money_touch.domain.routine.entity.RoutineAmount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RoutineAmountRepository extends JpaRepository<RoutineAmount, Long> {
+
+    @Query("SELECT ra FROM RoutineAmount ra JOIN FETCH ra.routine WHERE ra.routine.id = :routineId")
+    List<RoutineAmount> findAllWithRoutineByRoutineId(@Param("routineId") Long routineId);
+}

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandService.java
@@ -3,9 +3,13 @@ package com.server.money_touch.domain.routine.service;
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.global.validation.annotation.ExistBudget;
+import com.server.money_touch.global.validation.annotation.ExistRoutine;
 import com.server.money_touch.global.validation.annotation.ExistUser;
 
 public interface RoutineCommandService {
     // 소비 루틴 등록
     RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(@ExistUser Long userId, @ExistBudget Long budgetId, RoutineRequest.RoutineCreateDTO request);
+
+    // 타인의 소비 루틴을 내 예산에 반영
+    void applyRoutineToBudget(@ExistUser Long userId, @ExistBudget Long budgetId, @ExistRoutine Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.routine.service;
 
+import com.server.money_touch.domain.budget.converter.budgetCategory.BudgetCategoryConverter;
 import com.server.money_touch.domain.budget.entity.Budget;
 import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
@@ -28,6 +29,7 @@ import org.springframework.validation.annotation.Validated;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.server.money_touch.global.apiPayload.code.status.ErrorStatus.*;
 
@@ -147,5 +149,102 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         Long routineId = routine.getId();
         log.info("소비 루틴 등록 완료 - userId: {}, routineId: {}", userId, routineId);
         return RoutineConverter.toRoutineCreateResultDTO(routineId);
+    }
+
+    // 타인의 소비 루틴을 내 예산에 반영
+    @Transactional
+    @Override
+    public void applyRoutineToBudget(Long userId, Long budgetId, Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 소비 루틴 조회 (자신의 루틴은 허용하지 않음)
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        if (routine.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.ROUTINE_PREVIEW_NOT_ALLOWED);
+        }
+
+        // 3. 예산 조회
+        Budget budget = budgetRepository.findById(budgetId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
+
+        if (!budget.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.BUDGE_UNAUTHORIZED);
+        }
+
+        // 이미 루틴 적용된 예산이라면 예외
+        if (Boolean.TRUE.equals(budget.getIsFromRoutine())) {
+            throw new ErrorHandler(ErrorStatus.ROUTINE_ALREADY_APPLIED);
+        }
+
+        // 4. 총 카테고리 예산 합계 계산
+        int totalCategoryBudget = Stream.of(
+                        Optional.ofNullable(request.getDefaultCategoryBudgets()).orElse(List.of()),
+                        Optional.ofNullable(request.getCustomCategoryBudgets()).orElse(List.of()),
+                        Optional.ofNullable(request.getRoutineCategoryBudgets()).orElse(List.of()))
+                .flatMap(List::stream)
+                .mapToInt(RoutineRequest.ApplyCategoryBudgetDTO::getAmount)
+                .sum();
+
+        // 5. 총 예산과 일치 여부 검증
+        if (totalCategoryBudget > request.getTotalBudget()) {
+            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_EXCEEDED);
+        }
+        if (totalCategoryBudget < request.getTotalBudget()) {
+            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_TOO_LOW);
+        }
+
+        // 6. 총 예산 반영 및 루틴 플래그 true 처리
+        budget.updateTotalBudget(request.getTotalBudget());
+        budget.updateIsFromRoutine(true);
+
+        // 7. 기존 예산 카테고리 조회 → Map<String, BudgetCategory>
+        List<BudgetCategory> myCategories = budgetCategoryRepository.findByBudgetWithConsumptionCategory(budget);
+        Map<String, BudgetCategory> myCategoryMap = myCategories.stream()
+                .collect(Collectors.toMap(
+                        bc -> bc.getConsumptionCategory().getBudgetCategoryName(),
+                        Function.identity()
+                ));
+
+        // 8. 요청 카테고리 전체 순회 및 반영
+        Stream.of(
+                        Optional.ofNullable(request.getDefaultCategoryBudgets()).orElse(List.of()),
+                        Optional.ofNullable(request.getCustomCategoryBudgets()).orElse(List.of()),
+                        Optional.ofNullable(request.getRoutineCategoryBudgets()).orElse(List.of())
+                )
+                .flatMap(List::stream)
+                .forEach(dto -> {
+                    String name = dto.getCategoryName();
+                    Integer amount = dto.getAmount();
+                    CategoryType requestType = dto.getCategoryType();
+
+                    if (myCategoryMap.containsKey(name)) {
+                        // ✅ 기존 항목이 있는 경우 → 금액 갱신 및 타입 필요 시 갱신
+                        BudgetCategory existing = myCategoryMap.get(name);
+                        existing.updateAmount(amount);
+
+                        ConsumptionCategory category = existing.getConsumptionCategory();
+                        if (category.getBudgetCategoryType() != requestType) {
+                            category.updateCategoryType(requestType);
+                        }
+
+                    } else {
+                        // ✅ 기존 항목이 없는 경우 → 새로 생성
+                        ConsumptionCategory newCategory = ConsumptionCategory.builder()
+                                .user(user)
+                                .budgetCategoryName(name)
+                                .budgetCategoryType(requestType)
+                                .build();
+                        consumptionCategoryRepository.save(newCategory);
+
+                        BudgetCategory newBudgetCategory = BudgetCategoryConverter.toBudgetCategory(budget, newCategory, amount);
+                        budgetCategoryRepository.save(newBudgetCategory);
+                    }
+                });
+
+        log.info("타인의 소비 루틴을 내 예산에 반영 완료 - userId: {}, budgetId: {}, routineId: {}", userId, budgetId, routineId);
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -12,7 +12,9 @@ import com.server.money_touch.domain.routine.converter.RoutineHashtagConverter;
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.domain.routine.entity.Routine;
+import com.server.money_touch.domain.routine.entity.RoutineAmount;
 import com.server.money_touch.domain.routine.entity.RoutineHashtag;
+import com.server.money_touch.domain.routine.repository.routine.RoutineAmountRepository;
 import com.server.money_touch.domain.routine.repository.routineHashtag.RoutineHashtagRepository;
 import com.server.money_touch.domain.routine.repository.routine.RoutineRepository;
 import com.server.money_touch.domain.user.entity.User;
@@ -46,8 +48,11 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
     private final BudgetRepository budgetRepository;
     private final BudgetCategoryRepository budgetCategoryRepository;
     private final ConsumptionCategoryRepository consumptionCategoryRepository;
+    private final RoutineAmountRepository routineAmountRepository;
 
     // 소비 루틴 등록
+    // RoutineServiceImpl.java
+
     @Transactional
     @Override
     public RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(Long userId, Long budgetId, RoutineRequest.RoutineCreateDTO request) {
@@ -75,69 +80,31 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_TOO_LOW); // 총액 미달
         }
 
-        // 4. 예산 조회 및 예산 총액/루틴 여부 수정
+        // 4. 예산 존재 여부 확인 (예산과 관련된 데이터는 수정하지 않도록 구현 -> PM님 답변 오는거 보고 수정)
         Budget budget = budgetRepository.findById(budgetId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
-        budget.updateTotalBudget(request.getTotalBudget());
 
-        // 5. 요청된 카테고리 이름 → 금액 맵핑
-        Map<String, Integer> requestMap = request.getBudgetList().stream()
-                .collect(Collectors.toMap(RoutineRequest.CategoryBudgetDTO::getCategoryName, RoutineRequest.CategoryBudgetDTO::getAmount));
-
-        // 6. 해당 예산에 연결된 예산 카테고리 + 소비 카테고리 조회
-        List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllByBudgetIdWithCategory(budgetId);
-
-        // 7. categoryName → BudgetCategory 맵핑
-        Map<String, BudgetCategory> budgetCategoryMap = budgetCategories.stream()
-                .collect(Collectors.toMap(
-                        bc -> bc.getConsumptionCategory().getBudgetCategoryName(),
-                        Function.identity()
-                ));
-
-        // 8. 요청 기준으로 비교 후 금액 수정 or 새로 생성
-        for (Map.Entry<String, Integer> entry : requestMap.entrySet()) {
-            String categoryName = entry.getKey();
-            Integer amount = entry.getValue();
-
-            BudgetCategory category = budgetCategoryMap.get(categoryName);
-
-            if (category != null) {
-                if (!category.getBudgetCategoryMoney().equals(amount)) {
-                    category.updateAmount(amount);
-                }
-            } else {
-                // 존재하지 않는 경우 CUSTOM 타입 소비 카테고리 및 예산 카테고리 생성
-                ConsumptionCategory newCategory = ConsumptionCategory.builder()
-                        .budgetCategoryName(categoryName)
-                        .budgetCategoryType(CategoryType.CUSTOM)
-                        .user(user)
-                        .build();
-
-                ConsumptionCategory savedCategory = consumptionCategoryRepository.save(newCategory);
-
-                BudgetCategory newBudgetCategory = BudgetCategory.builder()
-                        .budget(budget)
-                        .consumptionCategory(savedCategory)
-                        .budgetCategoryMoney(amount)
-                        .build();
-
-                budgetCategoryRepository.save(newBudgetCategory);
-            }
-        }
-
-        // 8-1. 요청에 포함되지 않은 소비 카테고리 존재 시 예외 처리
-        budgetCategoryMap.keySet().stream()
-                .filter(categoryName -> !requestMap.containsKey(categoryName))
-                .findFirst()
-                .ifPresent(missing -> {
-                    throw new ErrorHandler(CONSUMPTION_CATEGORY_NAME_MISSING_IN_REQUEST);
-                });
-
-        // 9. 소비 루틴 저장
-        Routine routine = RoutineConverter.toRoutine(user, budget, request);
+        // 5. 소비 루틴 저장
+        Routine routine = Routine.builder()
+                .routineName(request.getRoutineName())
+                .routineImageUrl(request.getRoutineImgUrl())
+                .routineTotalAmount(request.getTotalBudget())
+                .budget(budget)
+                .user(user)
+                .build();
         routineRepository.save(routine);
 
-        // 10. 해시태그 저장
+        // 6. RoutineAmount 저장
+        List<RoutineAmount> routineAmounts = request.getBudgetList().stream()
+                .map(dto -> RoutineAmount.builder()
+                        .categoryName(dto.getCategoryName())
+                        .amount(dto.getAmount())
+                        .routine(routine)
+                        .build()
+                ).collect(Collectors.toList());
+        routineAmountRepository.saveAll(routineAmounts);
+
+        // 7. 해시태그 저장
         if (request.getHashtags() != null) {
             List<RoutineHashtag> hashtags = request.getHashtags().stream()
                     .map(tag -> RoutineHashtagConverter.toRoutineHashtag(routine, tag))
@@ -145,11 +112,89 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             routineHashtagRepository.saveAll(hashtags);
         }
 
-        // 11. 결과 DTO 반환
+        // 8. 결과 DTO 반환
         Long routineId = routine.getId();
         log.info("소비 루틴 등록 완료 - userId: {}, routineId: {}", userId, routineId);
         return RoutineConverter.toRoutineCreateResultDTO(routineId);
     }
+
+
+//    @Transactional
+//    @Override
+//    public RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(Long userId, Long budgetId, RoutineRequest.RoutineCreateDTO request) {
+//        // 1. 사용자 조회
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+//
+//        // 1-1. 이미 이번 달에 등록된 루틴이 있는지 확인
+//        if (routineRepository.existsByUserIdInCurrentMonth(userId)) {
+//            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+//        }
+//
+//        // 2. 카테고리 총합 계산
+//        int totalCategoryBudget = Optional.ofNullable(request.getBudgetList())
+//                .orElse(List.of())
+//                .stream()
+//                .mapToInt(RoutineRequest.CategoryBudgetDTO::getAmount)
+//                .sum();
+//
+//        // 3. 예산 총액과 일치 여부 확인
+//        if (totalCategoryBudget > request.getTotalBudget()) {
+//            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_EXCEEDED); // 총액 초과
+//        }
+//        if (totalCategoryBudget < request.getTotalBudget()) {
+//            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_TOO_LOW); // 총액 미달
+//        }
+//
+//        // 4. 예산 조회 및 예산 총액/루틴 여부 수정
+//        Budget budget = budgetRepository.findById(budgetId)
+//                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
+//        budget.updateTotalBudget(request.getTotalBudget());
+//
+//        // 5. 요청된 카테고리 이름 → 금액 맵핑
+//        Map<String, Integer> requestMap = request.getBudgetList().stream()
+//                .collect(Collectors.toMap(RoutineRequest.CategoryBudgetDTO::getCategoryName, RoutineRequest.CategoryBudgetDTO::getAmount));
+//
+//        // 6. 해당 예산에 연결된 예산 카테고리 + 소비 카테고리 조회
+//        List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllByBudgetIdWithCategory(budgetId);
+//
+//        // 7. categoryName → BudgetCategory 맵핑
+//        Map<String, BudgetCategory> budgetCategoryMap = budgetCategories.stream()
+//                .collect(Collectors.toMap(
+//                        bc -> bc.getConsumptionCategory().getBudgetCategoryName(),
+//                        Function.identity()
+//                ));
+//
+//        // 8. 요청 기준으로 비교 후 금액 수정 or 새로 생성
+//        for (Map.Entry<String, Integer> entry : requestMap.entrySet()) {
+//            String categoryName = entry.getKey();
+//            Integer amount = entry.getValue();
+//
+//            BudgetCategory category = budgetCategoryMap.get(categoryName);
+//
+//            if (category != null) {
+//                if (!category.getBudgetCategoryMoney().equals(amount)) {
+//                    category.updateAmount(amount);
+//                }
+//            } else {
+//                // 존재하지 않는 경우 CUSTOM 타입 소비 카테고리 및 예산 카테고리 생성
+//                ConsumptionCategory newCategory = ConsumptionCategory.builder()
+//                        .budgetCategoryName(categoryName)
+//                        .budgetCategoryType(CategoryType.CUSTOM)
+//                        .user(user)
+//                        .build();
+//
+//                ConsumptionCategory savedCategory = consumptionCategoryRepository.save(newCategory);
+//
+//                BudgetCategory newBudgetCategory = BudgetCategory.builder()
+//                        .budget(budget)
+//                        .consumptionCategory(savedCategory)
+//                        .budgetCategoryMoney(amount)
+//                        .build();
+//
+//                budgetCategoryRepository.save(newBudgetCategory);
+//            }
+//        }
 
     // 타인의 소비 루틴을 내 예산에 반영
     @Transactional

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
@@ -25,4 +25,7 @@ public interface RoutineQueryService {
 
     // 검색 키워드로 소비 루틴 목록 조회(커서 기반 무한스크롤)
     RoutineResponse.AllRoutineListDTO searchRoutineList(String keyword, Long cursorId);
+
+    // 타인의 소비 루틴을 내 예산에 반영 시 미리보기
+    RoutineResponse.ApplyRoutineInfoDTO getRoutineApplyInfo(@ExistUser Long userId, @ExistRoutine Long routineId);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
@@ -13,6 +13,7 @@ import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.constants.DefaultCategoryConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +25,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.time.LocalDate;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -158,4 +160,87 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
         Slice<RoutineResponse.RoutineListDTO> slice = routineRepository.searchRoutinesByKeyword(keyword, cursorId, pageable);
         return RoutineConverter.toAllRoutineListDTO(slice.getContent(), slice);
     }
+
+    // 타인의 소비 루틴을 내 예산에 반영 시 미리보기
+    @Override
+    public RoutineResponse.ApplyRoutineInfoDTO getRoutineApplyInfo(Long userId, Long routineId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 소비 루틴 조회 (자신의 루틴은 허용하지 않음)
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        if (routine.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.ROUTINE_PREVIEW_NOT_ALLOWED);
+        }
+
+        // 3. 해당 루틴의 예산 생성 월 기준으로 내 예산 조회
+        Budget budget = budgetRepository.findByUserAndCreatedMonth(user, routine.getBudget().getCreatedMonth())
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
+
+        if (Boolean.TRUE.equals(budget.getIsFromRoutine())) {
+            throw new ErrorHandler(ErrorStatus.ROUTINE_ALREADY_APPLIED);
+        }
+
+        // 4. 예산 카테고리 로드 (N+1 방지)
+        List<BudgetCategory> myCategories = budgetCategoryRepository.findByBudgetWithConsumptionCategory(budget);
+        List<BudgetCategory> routineCategories = budgetCategoryRepository.findByBudgetWithConsumptionCategory(routine.getBudget());
+
+        // 5. 이름 기준으로 Map 변환
+        Map<String, BudgetCategory> routineCategoryMap = routineCategories.stream()
+                .collect(Collectors.toMap(
+                        rc -> rc.getConsumptionCategory().getBudgetCategoryName(),
+                        Function.identity()
+                ));
+
+        Map<String, BudgetCategory> myCategoryMap = myCategories.stream()
+                .collect(Collectors.toMap(
+                        bc -> bc.getConsumptionCategory().getBudgetCategoryName(),
+                        Function.identity()
+                ));
+
+        Set<String> defaultNames = new HashSet<>(DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES);
+
+        // 6. Default 카테고리 구성 (무조건 포함)
+        List<RoutineResponse.ApplyCategoryBudgetDTO> defaultCategoryBudgets =
+                DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.stream()
+                        .map(name -> {
+                            int amount = routineCategoryMap.containsKey(name)
+                                    ? routineCategoryMap.get(name).getBudgetCategoryMoney()
+                                    : 0;
+                            return RoutineConverter.toCategoryDTO(name, amount, CategoryType.DEFAULT);
+                        })
+                        .collect(Collectors.toList());
+
+        // 7. 루틴에서만 존재하는 사용자 정의 카테고리 (default 제외)
+        List<RoutineResponse.ApplyCategoryBudgetDTO> routineCategoryBudgets = routineCategories.stream()
+                .filter(rc -> !defaultNames.contains(rc.getConsumptionCategory().getBudgetCategoryName()))
+                .map(RoutineConverter::toRoutineCategoryDTO)
+                .collect(Collectors.toList());
+
+        // 8. 내 예산에만 존재하고 루틴에는 없는 항목 → 금액 0으로 처리
+        List<RoutineResponse.ApplyCategoryBudgetDTO> customCategoryBudgets = myCategories.stream()
+                .filter(mc -> {
+                    String name = mc.getConsumptionCategory().getBudgetCategoryName();
+                    return !routineCategoryMap.containsKey(name) && !defaultNames.contains(name);
+                })
+                .map(mc -> RoutineConverter.toCategoryDTO(
+                        mc.getConsumptionCategory().getBudgetCategoryName(),
+                        0,
+                        mc.getConsumptionCategory().getBudgetCategoryType())
+                )
+                .collect(Collectors.toList());
+
+        log.info("소비 루틴 예산 반영 미리보기 완료 - userId: {}, routineId: {}", userId, routineId);
+
+        return RoutineConverter.toApplyRoutineInfoDTO(
+                routine.getBudget().getBudgetTotal(),
+                defaultCategoryBudgets,
+                customCategoryBudgets,
+                routineCategoryBudgets
+        );
+    }
+
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
@@ -8,6 +8,8 @@ import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCate
 import com.server.money_touch.domain.routine.converter.RoutineConverter;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.domain.routine.entity.Routine;
+import com.server.money_touch.domain.routine.entity.RoutineAmount;
+import com.server.money_touch.domain.routine.repository.routine.RoutineAmountRepository;
 import com.server.money_touch.domain.routine.repository.routine.RoutineRepository;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
@@ -41,6 +43,7 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
     private final UserRepository userRepository;
     private final BudgetCategoryRepository budgetCategoryRepository;
     private final BudgetRepository budgetRepository;
+    private final RoutineAmountRepository routineAmountRepository;
 
     // 소비 루틴 존재 여부 검증
     @Override
@@ -59,30 +62,19 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
         Routine routine = routineRepository.findByIdAndUserId(routineId, userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.ROUTINE_NOT_FOUND));
 
-        Budget budget = routine.getBudget();
+        // 3. 루틴 금액 정보 조회
+        List<RoutineAmount> routineAmounts = routineAmountRepository.findAllWithRoutineByRoutineId(routineId);
 
-        // 3. 예산-카테고리 목록 조회
-        List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllWithCategoryByBudgetId(budget.getId());
-
-        // 4. categoryType별로 분류
-        Map<CategoryType, List<BudgetCategory>> groupedByType = budgetCategories.stream()
-                .collect(Collectors.groupingBy(bc -> bc.getConsumptionCategory().getBudgetCategoryType()));
-
-        // 5. CategoryBudgetDetailDTO 변환 (기본 → 커스텀 → 루틴 순서 유지)
-        List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = Stream.of(
-                        CategoryType.DEFAULT,
-                        CategoryType.CUSTOM,
-                        CategoryType.ROUTINE_CATEGORY
-                )
-                .flatMap(type -> groupedByType.getOrDefault(type, Collections.emptyList()).stream())
-                .map(bc -> RoutineResponse.CategoryBudgetDetailDTO.builder()
-                        .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
-                        .amount(bc.getBudgetCategoryMoney())
+        // 4. 카테고리 정보 DTO로 변환
+        List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = routineAmounts.stream()
+                .map(ra -> RoutineResponse.CategoryBudgetDetailDTO.builder()
+                        .categoryName(ra.getCategoryName())
+                        .amount(ra.getAmount())
                         .build())
                 .collect(Collectors.toList());
 
         log.info("내 소비 루틴 상세 조회 완료 - userId: {}, routeIneId: {}", userId, routineId);
-        return RoutineConverter.toRoutineDetailDTO(budget.getBudgetTotal(), routine.getRoutineName(), categoryBudgetList);
+        return RoutineConverter.toRoutineDetailDTO(routine.getRoutineTotalAmount(), routine.getRoutineName(), categoryBudgetList);
     }
 
     // 내 소비 루틴 목록 조회 (커서 기반 무한스크롤)
@@ -118,23 +110,26 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
     }
 
     // 타인 소비 루틴 상세 조회
+    // 타인 소비 루틴 상세 조회
     @Override
     public RoutineResponse.RoutineListDetailDTO getOtherRoutineDetail(Long userId, Long routineId) {
+        // 1. 루틴 조회
         Routine routine = routineRepository.findById(routineId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.ROUTINE_NOT_FOUND));
 
-        Budget routineBudget = routine.getBudget();
-        List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllWithCategoryByBudgetId(routineBudget.getId());
+        // 2. 루틴 금액 정보 조회
+        List<RoutineAmount> routineAmounts = routineAmountRepository.findAllWithRoutineByRoutineId(routineId);
 
-        // 금액이 0원인 카테고리 제외
-        List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = budgetCategories.stream()
-                .filter(bc -> bc.getBudgetCategoryMoney() != null && bc.getBudgetCategoryMoney() > 0)
-                .map(bc -> RoutineResponse.CategoryBudgetDetailDTO.builder()
-                        .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
-                        .amount(bc.getBudgetCategoryMoney())
+        // 3. 금액이 0원 초과인 항목만 필터링 및 DTO 변환
+        List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = routineAmounts.stream()
+                .filter(ra -> ra.getAmount() != null && ra.getAmount() > 0)
+                .map(ra -> RoutineResponse.CategoryBudgetDetailDTO.builder()
+                        .categoryName(ra.getCategoryName())
+                        .amount(ra.getAmount())
                         .build())
-                .toList();
+                .collect(Collectors.toList());
 
+        // 4. 사용자 예산 정보로 적용 가능 여부 판단
         String createdMonth = LocalDate.now().withDayOfMonth(1).toString().substring(0, 7);
         Optional<Budget> myBudgetOpt = budgetRepository.findByUserIdAndCreatedMonth(userId, createdMonth);
 
@@ -146,7 +141,7 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
         }
 
         return RoutineResponse.RoutineListDetailDTO.builder()
-                .totalBudget(routineBudget.getBudgetTotal())
+                .totalBudget(routine.getRoutineTotalAmount())
                 .routineName(routine.getRoutineName())
                 .categoryBudgetList(categoryBudgetList)
                 .canApply(canApply)
@@ -177,66 +172,67 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
         }
 
         // 3. 해당 루틴의 예산 생성 월 기준으로 내 예산 조회
-        Budget budget = budgetRepository.findByUserAndCreatedMonth(user, routine.getBudget().getCreatedMonth())
+        Budget myBudget = budgetRepository.findByUserAndCreatedMonth(user, routine.getBudget().getCreatedMonth())
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
 
-        if (Boolean.TRUE.equals(budget.getIsFromRoutine())) {
+        if (Boolean.TRUE.equals(myBudget.getIsFromRoutine())) {
             throw new ErrorHandler(ErrorStatus.ROUTINE_ALREADY_APPLIED);
         }
 
-        // 4. 예산 카테고리 로드 (N+1 방지)
-        List<BudgetCategory> myCategories = budgetCategoryRepository.findByBudgetWithConsumptionCategory(budget);
-        List<BudgetCategory> routineCategories = budgetCategoryRepository.findByBudgetWithConsumptionCategory(routine.getBudget());
-
-        // 5. 이름 기준으로 Map 변환
-        Map<String, BudgetCategory> routineCategoryMap = routineCategories.stream()
-                .collect(Collectors.toMap(
-                        rc -> rc.getConsumptionCategory().getBudgetCategoryName(),
-                        Function.identity()
-                ));
-
+        // 4. 내 예산의 소비 카테고리 로드
+        List<BudgetCategory> myCategories = budgetCategoryRepository.findByBudgetWithConsumptionCategory(myBudget);
         Map<String, BudgetCategory> myCategoryMap = myCategories.stream()
                 .collect(Collectors.toMap(
                         bc -> bc.getConsumptionCategory().getBudgetCategoryName(),
                         Function.identity()
                 ));
 
+        // 5. 루틴 금액 정보 조회
+        List<RoutineAmount> routineAmounts = routineAmountRepository.findAllWithRoutineByRoutineId(routineId);
+        Map<String, Integer> routineAmountMap = routineAmounts.stream()
+                .collect(Collectors.toMap(RoutineAmount::getCategoryName, RoutineAmount::getAmount));
+
+        // 6. Default 카테고리 처리
         Set<String> defaultNames = new HashSet<>(DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES);
 
-        // 6. Default 카테고리 구성 (무조건 포함)
         List<RoutineResponse.ApplyCategoryBudgetDTO> defaultCategoryBudgets =
                 DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.stream()
                         .map(name -> {
-                            int amount = routineCategoryMap.containsKey(name)
-                                    ? routineCategoryMap.get(name).getBudgetCategoryMoney()
-                                    : 0;
+                            int amount = routineAmountMap.getOrDefault(name, 0);
                             return RoutineConverter.toCategoryDTO(name, amount, CategoryType.DEFAULT);
                         })
                         .collect(Collectors.toList());
 
-        // 7. 루틴에서만 존재하는 사용자 정의 카테고리 (default 제외)
-        List<RoutineResponse.ApplyCategoryBudgetDTO> routineCategoryBudgets = routineCategories.stream()
-                .filter(rc -> !defaultNames.contains(rc.getConsumptionCategory().getBudgetCategoryName()))
-                .map(RoutineConverter::toRoutineCategoryDTO)
+        // 7. 루틴 기반 ROUTINE_CATEGORY 구성 (CUSTOM과 이름이 겹치는 항목 포함)
+        Set<String> routineCategoryNames = new HashSet<>();
+        List<RoutineResponse.ApplyCategoryBudgetDTO> routineCategoryBudgets = routineAmounts.stream()
+                .filter(ra -> !defaultNames.contains(ra.getCategoryName()))
+                .map(ra -> {
+                    String name = ra.getCategoryName();
+                    int amount = ra.getAmount();
+                    routineCategoryNames.add(name);
+                    return RoutineConverter.toCategoryDTO(name, amount, CategoryType.ROUTINE_CATEGORY);
+                })
                 .collect(Collectors.toList());
 
-        // 8. 내 예산에만 존재하고 루틴에는 없는 항목 → 금액 0으로 처리
+        // 8. 내 예산의 CUSTOM 항목 중 루틴에 포함되지 않은 항목만 CUSTOM으로 유지
         List<RoutineResponse.ApplyCategoryBudgetDTO> customCategoryBudgets = myCategories.stream()
                 .filter(mc -> {
                     String name = mc.getConsumptionCategory().getBudgetCategoryName();
-                    return !routineCategoryMap.containsKey(name) && !defaultNames.contains(name);
+                    return mc.getConsumptionCategory().getBudgetCategoryType() == CategoryType.CUSTOM &&
+                            !routineCategoryNames.contains(name);
                 })
                 .map(mc -> RoutineConverter.toCategoryDTO(
                         mc.getConsumptionCategory().getBudgetCategoryName(),
                         0,
-                        mc.getConsumptionCategory().getBudgetCategoryType())
+                        CategoryType.CUSTOM)
                 )
                 .collect(Collectors.toList());
 
         log.info("소비 루틴 예산 반영 미리보기 완료 - userId: {}, routineId: {}", userId, routineId);
 
         return RoutineConverter.toApplyRoutineInfoDTO(
-                routine.getBudget().getBudgetTotal(),
+                routine.getRoutineTotalAmount(),
                 defaultCategoryBudgets,
                 customCategoryBudgets,
                 routineCategoryBudgets

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -61,7 +61,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 소비 루틴 관련 에러
     ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE4001", "아이디와 일치하는 소비 루틴이 없습니다."),
     ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE4002", "한 달 소비 루틴 등록 횟수를 초과하였습니다."),
+    ROUTINE_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "ROUTINE4003", "한 달 소비 루틴 가져오기 횟수를 초과하였습니다."),
+    ROUTINE_PREVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "ROUTINE4004", "자신의 소비 루틴은 미리보기로 가져올 수 없습니다."),
     ERROR_UPLOAD_ROUTINE_IMG(HttpStatus.INTERNAL_SERVER_ERROR, "ROUTINE5001", "소비 루틴 이미지 등록에 실패하였습니다."),
+
 
     // 알림 관련 에러
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "존재하지 않는 알림입니다."),

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BUDGET_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "BUDGET4004", "한 달 예산 등록 횟수를 초과하였습니다."),
     BUDGET_NOT_EXIST(HttpStatus.NOT_FOUND, "BUDGET_4041", "이번달에 등록된 예산이 없습니다."),
     ROUTINE_CATEGORY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BUDGET_403", "소비 루틴 카테고리는 소비 루틴을 등록한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 설정할 수 있습니다."),
+    BUDGE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "BUDGET4011", "접근 권한이 없는 예산 아이디입니다. 예산 아이디 조회를 통해 올바른 예산 아이디로 구성해주세요."),
 
     // 소비 MBTI 관련 에러
     MBTI_NOT_FOUND(HttpStatus.BAD_REQUEST, "MBTI4001", "해당하는 소비 MBTI가 없습니다."),


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #109 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 소비 루틴 금액 관련 테이블 `RoutineAmount` 생성
  - 루틴에 포함된 각 카테고리별 금액을 관리하기 위한 전용 테이블
  - 기존에는 `ConsumptionCategory`, `BudgetCategory`의 데이터를 기반으로 했으나,  **예산이 바뀌면 등록된 소비 루틴의 금액이 바뀌는 오류를 해결하기 위해** 별도 테이블로 분리
- 내 소비 루틴 상세 조회 및 타인의 소비 루틴 상세 조회
  - 모두 기존의 `ConsumptionCategory`, `BudgetCategory` 기반 조회에서 → `RoutineAmount` 기반 조회로 수정하여 루틴의 실질적인 금액 정보가 반영되도록 개선
- 타인의 소비 루틴을 내 예산에 반영 전 미리보기 구현
  - 사용자가 이미 내 소비 카테고리(CUSTOM)로 구성한 데이터가 있을 경우 해당 데이터를 그대로 소비 카테고리로 반환합니다.(금액은 0원으로 변경됨) 단, 소비 루틴 카테고리와 동일한 이름의 항목이 존재할 경우, 해당 항목은 소비 루틴 카테고리로 타입이 변경되어 반환됩니다.
- 타인의 소비 루틴을 내 예산에 반영
  - 타인의 소비 루틴을 내 예산에 반영하는 API를 먼저 호출하여 해당 데이터를 기반으로 예산을 구성 후, 해당 데이터를 예산에 반영
  - `Budget`의 `isFromeRoutine` 필드를 true로 변경
- 예산 아이디 조회 오류 수정
  -  사용자가 등록/수정한 예산이 있음에도 불구하고`budgetId`가 계속 null로 반환되는 오류 수정  -> JPQL 쿼리 메서드에서 조회 조건을 수정

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  소비 루틴을 등록할 때 내 예산 데이터를 불러와 이를 기반으로 금액을 구성하게 되는데, 이 과정에서 소비 루틴을 등록하면 예산 금액도 함께 변경되는지에 대한 기획이 명확하지 않아 PM님께 해당 부분을 문의드렸습니다.
PM님의 답변을 확인한 후, 필요한 경우 수정 작업을 진행할 예정입니다.
(예: 기존 한 달 예산이 30만 원이고, 이에 맞춰 카테고리 금액도 구성되어 있었는데, 소비 루틴 등록 시 예산 총액을 50만 원으로 변경하고 카테고리 금액도 50만 원 기준으로 수정한 경우, 실제 한 달 예산도 50만 원으로 함께 변경되는 것인지 여부가 불분명합니다.)

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="480" height="420" alt="스크린샷 2025-08-03 오후 10 55 23" src="https://github.com/user-attachments/assets/e4f55545-1628-4773-99a6-cad7594d5fa2" />

소비 루틴 예산 반영 전 수정/추가(미리보기). 

<img width="488" height="563" alt="스크린샷 2025-08-03 오후 10 59 08" src="https://github.com/user-attachments/assets/4d19570f-9462-4ed5-bc3e-dd3691e6fc44" />

소비 루틴을 내 예산에 반영하되, 반영 대상 소비 루틴의 데이터를 기반으로 예산을 구성한 후, 추가로 CUSTOM(내 소비 카테고리) 항목을 포함한 경우 및 소비 루틴 카테고리의 금액을 수정한 경우. 

<img width="714" height="602" alt="스크린샷 2025-08-03 오후 11 02 18" src="https://github.com/user-attachments/assets/94eeb1d2-d5a5-45e2-b509-7b75f3d7a5db" />

예산 조회를 통해 소비 루틴 관련 금액이 예산에 반영되었는지 확인. 

## 💬 리뷰 요구사항 (선택)
> 소비 루틴&예산 쪽이 너무 복잡하고 헷갈려서.. 중간에 수정된 부분도 많아서, 현재 DB 상의 금액 데이터가 실제와 맞지 않는 오류가 발생할 수 있을 것 같습니다.. 