### PR TITLE
✨Feat : 소비 MBTI 결과 조회 기능 구현

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
@@ -2,6 +2,7 @@ package com.server.money_touch.domain.consumptionMbti.controller;
 
 
 import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
+import com.server.money_touch.domain.consumptionMbti.service.ConsumptionMbtiService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
@@ -26,6 +27,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/consumptionMbti")
 public class ConsumptionMbtiController {
 
+    private final ConsumptionMbtiService consumptionMbtiService;
+
     @Operation(
             summary = "소비 Mbti 조회 API",
             description = "결과 코드(예: PTG)에 해당하는 소비 MBTI 설명, 부제, 이미지 등을 조회합니다."
@@ -41,7 +44,7 @@ public class ConsumptionMbtiController {
     })
     @GetMapping("/result")
     public ApiResponse<ConsumptionMbtiResponse.ConsumptionMbtiResultDTO> getMbti(@RequestParam @NotBlank(message = "결과값은 필수입니다.") String result) {
-        ConsumptionMbtiResponse.ConsumptionMbtiResultDTO response = null; //  TODO: 서비스 연결 예정
+        var response = consumptionMbtiService.getConsumptionMbti(result);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/controller/ConsumptionMbtiController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -43,8 +44,8 @@ public class ConsumptionMbtiController {
             @Parameter(name = "result" , description = "조회하려는 소비 MBTI", example = "PTG" , required = true)
     })
     @GetMapping("/result")
-    public ApiResponse<ConsumptionMbtiResponse.ConsumptionMbtiResultDTO> getMbti(@RequestParam @NotBlank(message = "결과값은 필수입니다.") String result) {
-        var response = consumptionMbtiService.getConsumptionMbti(result);
+    public ApiResponse<ConsumptionMbtiResponse.ConsumptionMbtiResultDTO> getMbti(@RequestParam @NotBlank(message = "결과값은 필수입니다.") String result, HttpServletRequest request) {
+        var response = consumptionMbtiService.getConsumptionMbti(result, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/converter/ConsumptionMbtiConveter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/converter/ConsumptionMbtiConveter.java
@@ -1,0 +1,18 @@
+package com.server.money_touch.domain.consumptionMbti.converter;
+
+import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
+import com.server.money_touch.domain.consumptionMbti.entity.ConsumptionMbti;
+
+public class ConsumptionMbtiConveter {
+
+    public static ConsumptionMbtiResponse.ConsumptionMbtiResultDTO toResultDTO(ConsumptionMbti entity) {
+        return new ConsumptionMbtiResponse.ConsumptionMbtiResultDTO(
+                entity.getId(),
+                entity.getResult(),
+                entity.getSubtitle(),
+                entity.getMbtiImgUrl(),
+                entity.getDescription()
+        );
+
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/dto/ConsumptionMbtiResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/dto/ConsumptionMbtiResponse.java
@@ -18,6 +18,9 @@ public class ConsumptionMbtiResponse {
         @Schema(description = "소비 mbti 이름", example = "PTG")
         private String result;
 
+        @Schema(description = "소비 mbti 부제" , example = "계획 철벽러")
+        private String subtitle;
+
         @Schema(description = "소비 mbti 설명" ,example = "철저한 계획 아래~")
         private String description;
 

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/entity/ConsumptionMbti.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/entity/ConsumptionMbti.java
@@ -21,12 +21,15 @@ public class ConsumptionMbti {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length = 10, nullable = false, unique = true)
+    private String result; // 소비MBTI 이름 ex) PTG
+
+    private String subtitle; // ex) 계획 철벽러
+
     private String mbtiImgUrl;
 
     private String description;
 
-    @Column(length = 10)
-    private String result; // 소비MBTI 이름 ex) PTG
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/repository/ConsumptionMbtiRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/repository/ConsumptionMbtiRepository.java
@@ -1,0 +1,11 @@
+package com.server.money_touch.domain.consumptionMbti.repository;
+
+import com.server.money_touch.domain.consumptionMbti.entity.ConsumptionMbti;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface ConsumptionMbtiRepository extends CrudRepository<ConsumptionMbti, Long> {
+    // 소비 MBTI 존재 유무 확인
+    Optional <ConsumptionMbti> findByCode(String code);
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/repository/ConsumptionMbtiRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/repository/ConsumptionMbtiRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface ConsumptionMbtiRepository extends CrudRepository<ConsumptionMbti, Long> {
     // 소비 MBTI 존재 유무 확인
-    Optional <ConsumptionMbti> findByCode(String code);
+    Optional <ConsumptionMbti> findByResult(String result);
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiService.java
@@ -1,0 +1,13 @@
+package com.server.money_touch.domain.consumptionMbti.service;
+
+
+import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
+
+public interface ConsumptionMbtiService {
+    // 소비 MBTI 존재 여부 검증
+    Boolean existsConsumptionMbti(Long consumptionMbtiId);
+
+    // 소비 MBTI 조회
+    ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String code);
+
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiService.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiService.java
@@ -2,12 +2,13 @@ package com.server.money_touch.domain.consumptionMbti.service;
 
 
 import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface ConsumptionMbtiService {
     // 소비 MBTI 존재 여부 검증
     Boolean existsConsumptionMbti(Long consumptionMbtiId);
 
     // 소비 MBTI 조회
-    ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String code);
+    ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String result, HttpServletRequest request);
 
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiServiceImpl.java
@@ -1,0 +1,32 @@
+package com.server.money_touch.domain.consumptionMbti.service;
+
+import com.server.money_touch.domain.consumptionMbti.converter.ConsumptionMbtiConveter;
+import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
+import com.server.money_touch.domain.consumptionMbti.entity.ConsumptionMbti;
+import com.server.money_touch.domain.consumptionMbti.repository.ConsumptionMbtiRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionMbtiServiceImpl implements ConsumptionMbtiService{
+
+    private final ConsumptionMbtiRepository consumptionMbtiRepository;
+
+    // 소비 MBTI 존재 여부 검증
+    @Override
+    public Boolean existsConsumptionMbti(Long ConsumptionMbtiId) {
+        return consumptionMbtiRepository.existsById(ConsumptionMbtiId);
+    }
+
+
+    @Override
+    public ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String code) {
+        ConsumptionMbti consumptionMbti = consumptionMbtiRepository.findByCode(code)
+                .orElseThrow(()-> new ErrorHandler(ErrorStatus.MBTI_NOT_FOUND));
+        return ConsumptionMbtiConveter.toResultDTO(consumptionMbti);
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiServiceImpl.java
@@ -4,16 +4,24 @@ import com.server.money_touch.domain.consumptionMbti.converter.ConsumptionMbtiCo
 import com.server.money_touch.domain.consumptionMbti.dto.ConsumptionMbtiResponse;
 import com.server.money_touch.domain.consumptionMbti.entity.ConsumptionMbti;
 import com.server.money_touch.domain.consumptionMbti.repository.ConsumptionMbtiRepository;
+import com.server.money_touch.domain.user.entity.User;
+import com.server.money_touch.domain.user.repository.user.UserRepository;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import com.server.money_touch.global.utils.AuthUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ConsumptionMbtiServiceImpl implements ConsumptionMbtiService{
 
     private final ConsumptionMbtiRepository consumptionMbtiRepository;
+    private final AuthUtil authUtil;
+    private final UserRepository userRepository;
 
     // 소비 MBTI 존재 여부 검증
     @Override
@@ -21,11 +29,29 @@ public class ConsumptionMbtiServiceImpl implements ConsumptionMbtiService{
         return consumptionMbtiRepository.existsById(ConsumptionMbtiId);
     }
 
+    // 유저 프로필이미지 존재 여부 검증
+
 
     @Override
-    public ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String result) {
+    public ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String result, HttpServletRequest request) {
+        // 1. MBTI 결과 조회
         ConsumptionMbti consumptionMbti = consumptionMbtiRepository.findByResult(result)
-                .orElseThrow(()-> new ErrorHandler(ErrorStatus.MBTI_NOT_FOUND));
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.MBTI_NOT_FOUND));
+
+        // 2. 현재 로그인한 유저 ID 추출
+        Long userId = authUtil.getUserIdFromRequest(request);
+
+        // 3. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 유저의 프로필 이미지가 없고, 소비 MBTI 이미지가 존재할 경우
+        if ((user.getProfileImgUrl() == null || user.getProfileImgUrl().isBlank())
+                && consumptionMbti.getMbtiImgUrl() != null && !consumptionMbti.getMbtiImgUrl().isBlank()) {
+            user.setProfileImgUrl(consumptionMbti.getMbtiImgUrl());
+            userRepository.save(user); // 유저 정보 저장
+        }
+
         return ConsumptionMbtiConveter.toResultDTO(consumptionMbti);
     }
 

--- a/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionMbti/service/ConsumptionMbtiServiceImpl.java
@@ -23,8 +23,8 @@ public class ConsumptionMbtiServiceImpl implements ConsumptionMbtiService{
 
 
     @Override
-    public ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String code) {
-        ConsumptionMbti consumptionMbti = consumptionMbtiRepository.findByCode(code)
+    public ConsumptionMbtiResponse.ConsumptionMbtiResultDTO getConsumptionMbti(String result) {
+        ConsumptionMbti consumptionMbti = consumptionMbtiRepository.findByResult(result)
                 .orElseThrow(()-> new ErrorHandler(ErrorStatus.MBTI_NOT_FOUND));
         return ConsumptionMbtiConveter.toResultDTO(consumptionMbti);
     }

--- a/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
+++ b/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
@@ -12,7 +12,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u LEFT JOIN FETCH u.userDetail")
     List<User> findAllWithUserDetail();
 
-    Optional<User> findByEmail(String email); // email로 사용자 정보를 가져옴
+    // email로 유저 조회
+    Optional<User> findByEmail(String email);
 
-    boolean existsByEmail(String email);
+    Optional<User> findById(Long id);
+    
 }

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -34,6 +34,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final UserQueryService userQueryService;
     private final BudgetCommandService budgetCommandService;
     private final TotalConsumptionRepository totalConsumptionRepository;
 
@@ -46,7 +47,7 @@ public class AuthService {
         User user;
         boolean isNewUser = false;
 
-        if (userRepository.existsByEmail(email)) {
+        if (userQueryService.existsByEmail(email)) {
             user = userRepository.findByEmail(email).get();
         } else {
             user = createNewUser(kakaoProfile); // 등록되지않은 회원이면 회원가입

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
@@ -43,6 +43,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final UserQueryService userQueryService;
     private final BudgetCommandService budgetCommandService;
     private final TotalConsumptionRepository totalConsumptionRepository;
 
@@ -181,7 +182,7 @@ public class UserCommandServiceImpl implements UserCommandService {
      * 이메일 중복 검증
      */
     private void validateDuplicateEmail(String email) {
-        if (userRepository.existsByEmail(email)) {
+        if (userQueryService.existsByEmail(email)) {
             throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
         }
     }

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryService.java
@@ -6,6 +6,10 @@ public interface UserQueryService {
     // User 존재 여부 검증
     Boolean existsUserById(Long userId);
 
+    // email 존재 여부 검증
+    Boolean existsByEmail(String email);
+
+
     // 마이페이지 유저 정보 조회
     UserResponse.MyPageResponseDTO getMyPageInfo(Long userId);
 }

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
@@ -29,6 +29,11 @@ public class UserQueryServiceImpl implements UserQueryService {
         return userRepository.findById(userId).isPresent();
     }
 
+    // 이메일 존재 여부 검증
+    @Override
+    public Boolean existsByEmail(String email){return userRepository.findByEmail(email).isPresent();}
+
+
     // 마이페이지
     @Override
     public UserResponse.MyPageResponseDTO getMyPageInfo(Long userId) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#114 

## 📝 작업 내용
<img width="1349" height="776" alt="image" src="https://github.com/user-attachments/assets/8b8eb42f-ddc7-4ab7-b6a7-b102834fe59b" />
MBTI 결과를 파라미터로 전송받으면 DB저장되어있는 결과에 해당하는 데이터를 응답으로 보내줍니다.
또한 해당 유저와 연관관계를 갖게됩니다.

--------
<img width="546" height="106" alt="image" src="https://github.com/user-attachments/assets/29ef1f80-8207-481b-8c33-6d1926d44499" />


유저의 프로필이미지가 존재하지않을경우, MBTI의 이미지로 변경됩니다.

## 📌 공유 사항
소비 MBTI 엔티티에 String subtitle이 추가되었습니다 ..!


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?
