### PR TITLE
[#119] 🐛Fix: 소비 루틴 상세 조회 시 금액 0원 보이지 않는 오류 수정 및 DTO 컨버터 리팩토링

### DIFF
--- a/src/main/java/com/server/money_touch/MoneyTouchApplication.java
+++ b/src/main/java/com/server/money_touch/MoneyTouchApplication.java
@@ -3,12 +3,13 @@ package com.server.money_touch;
 import com.server.money_touch.global.config.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
 @EnableAsync
 @EnableScheduling
 @SpringBootApplication

--- a/src/main/java/com/server/money_touch/domain/budget/converter/budget/BudgetConverter.java
+++ b/src/main/java/com/server/money_touch/domain/budget/converter/budget/BudgetConverter.java
@@ -1,8 +1,9 @@
 package com.server.money_touch.domain.budget.converter.budget;
 
-import com.server.money_touch.domain.budget.dto.BudgetRequest;
 import com.server.money_touch.domain.budget.dto.BudgetResponse;
 import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.entity.BudgetCategory;
+import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.user.entity.User;
 
 import java.time.LocalDate;
@@ -30,14 +31,23 @@ public class BudgetConverter {
 
     // 내 예산 조회 응답 DTO 반환
     public static BudgetResponse.BudgetDetailDTO toBudgetDetailDTO(Budget budget,
-                                                                   List<BudgetResponse.DefaultCategoryBudgetResponse> defaultCategories,
-                                                                   List<BudgetResponse.CustomCategoryBudgetResponse> customCategories,
-                                                                   List<BudgetResponse.RoutineCategoryBudgetResponse> routineCategories) {
+                                                                   List<BudgetResponse.BudgetDetailCategoryBudgetResponse> defaultCategories,
+                                                                   List<BudgetResponse.BudgetDetailCategoryBudgetResponse> customCategories,
+                                                                   List<BudgetResponse.BudgetDetailCategoryBudgetResponse> routineCategories) {
         return BudgetResponse.BudgetDetailDTO.builder()
                 .totalBudget(budget.getBudgetTotal())
                 .defaultCategoryBudgets(defaultCategories)
                 .customCategoryBudgets(customCategories)
                 .routineCategoryBudgets(routineCategories)
+                .build();
+    }
+
+    // 내 예산 조회 시 카테고리별 예산 응답 DTO 변환
+    public static BudgetResponse.BudgetDetailCategoryBudgetResponse toBudgetDetailCategoryBudgetResponse(BudgetCategory bc) {
+        return BudgetResponse.BudgetDetailCategoryBudgetResponse.builder()
+                .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
+                .amount(bc.getBudgetCategoryMoney())
+                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -42,13 +42,13 @@ public class BudgetResponse {
         private Integer totalBudget;
 
         @Schema(description = "기본 카테고리별 예산 목록")
-        private List<BudgetResponse.DefaultCategoryBudgetResponse> defaultCategoryBudgets;
+        private List<BudgetDetailCategoryBudgetResponse> defaultCategoryBudgets;
 
         @Schema(description = "내 카테고리별 예산 목록")
-        private List<BudgetResponse.CustomCategoryBudgetResponse> customCategoryBudgets;
+        private List<BudgetResponse.BudgetDetailCategoryBudgetResponse> customCategoryBudgets;
 
         @Schema(description = "소비 루틴 카테고리 예산 목록")
-        private List<BudgetResponse.RoutineCategoryBudgetResponse> routineCategoryBudgets;
+        private List<BudgetResponse.BudgetDetailCategoryBudgetResponse> routineCategoryBudgets;
     }
 
     @Builder
@@ -56,43 +56,11 @@ public class BudgetResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(description = "기본 카테고리별 예산")
-    public static class DefaultCategoryBudgetResponse {
-        @Schema(description = "기본 예산 카테고리명", example = "배달/외식")
+    public static class BudgetDetailCategoryBudgetResponse {
+        @Schema(description = "예산 카테고리명", example = "배달/외식")
         private String categoryName;
 
         @Schema(description = "카테고리별 예산 금액", example = "200000")
-        private Integer amount;
-
-        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
-        private CategoryType categoryType;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Schema(description = "사용자 정의 카테고리별 예산")
-    public static class CustomCategoryBudgetResponse {
-        @Schema(description = "사용자 정의 카테고리명", example = "교육비")
-        private String categoryName;
-
-        @Schema(description = "카테고리별 예산 금액", example = "150000")
-        private Integer amount;
-
-        @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")
-        private CategoryType categoryType;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Schema(description = "소비 루틴 카테고리 예산")
-    public static class RoutineCategoryBudgetResponse {
-        @Schema(description = "소비 루틴 카테고리명", example = "술/유흥")
-        private String categoryName;
-
-        @Schema(description = "카테고리별 예산 금액", example = "150000")
         private Integer amount;
 
         @Schema(description = "카테고리 타입", example = "DEFAULT / CUSTOM / ROUTINE_CATEGORY")

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -7,7 +7,6 @@ import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
 import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
-import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
 import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
 import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
 import com.server.money_touch.domain.user.entity.User;
@@ -60,29 +59,20 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
                 .collect(Collectors.groupingBy(bc -> bc.getConsumptionCategory().getBudgetCategoryType()));
 
         // 3-1. 공통 처리 함수 사용하여 DTO 변환
-        List<BudgetResponse.DefaultCategoryBudgetResponse> defaultCategories =
+        List<BudgetResponse.BudgetDetailCategoryBudgetResponse> defaultCategories =
                 convertBudgetCategories(groupedByType.get(CategoryType.DEFAULT),
-                        bc -> BudgetResponse.DefaultCategoryBudgetResponse.builder()
-                                .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
-                                .amount(bc.getBudgetCategoryMoney())
-                                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
-                                .build());
+                        BudgetConverter::toBudgetDetailCategoryBudgetResponse
+                );
 
-        List<BudgetResponse.CustomCategoryBudgetResponse> customCategories =
+        List<BudgetResponse.BudgetDetailCategoryBudgetResponse> customCategories =
                 convertBudgetCategories(groupedByType.get(CategoryType.CUSTOM),
-                        bc -> BudgetResponse.CustomCategoryBudgetResponse.builder()
-                                .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
-                                .amount(bc.getBudgetCategoryMoney())
-                                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
-                                .build());
+                        BudgetConverter::toBudgetDetailCategoryBudgetResponse
+                );
 
-        List<BudgetResponse.RoutineCategoryBudgetResponse> routineCategories =
+        List<BudgetResponse.BudgetDetailCategoryBudgetResponse> routineCategories =
                 convertBudgetCategories(groupedByType.get(CategoryType.ROUTINE_CATEGORY),
-                        bc -> BudgetResponse.RoutineCategoryBudgetResponse.builder()
-                                .categoryName(bc.getConsumptionCategory().getBudgetCategoryName())
-                                .amount(bc.getBudgetCategoryMoney())
-                                .categoryType(bc.getConsumptionCategory().getBudgetCategoryType())
-                                .build());
+                        BudgetConverter::toBudgetDetailCategoryBudgetResponse
+                );
 
         // 4. 응답 DTO 구성
         log.info("예산 조회 완료 - userId: {}, budgetId: {}", userId, budgetId);

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/household/HouseholdConsumptionConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/household/HouseholdConsumptionConverter.java
@@ -1,0 +1,18 @@
+package com.server.money_touch.domain.consumptionRecord.converter.household;
+
+import com.server.money_touch.domain.consumptionRecord.dto.HouseholdConsumptionResponse;
+import com.server.money_touch.domain.consumptionRecord.projection.DailyConsumptionItemDetailProjection;
+
+public class HouseholdConsumptionConverter {
+
+    // 달력에서 특정 날짜의 소비 내역 상세 조회 응답 DTO 변환
+    public static HouseholdConsumptionResponse.ConsumeItemDTO toConsumeItem(DailyConsumptionItemDetailProjection dailyConsumptionItem) {
+        return HouseholdConsumptionResponse.ConsumeItemDTO.builder()
+                .consumptionRecordId(dailyConsumptionItem.getConsumptionRecordId())
+                .categoryName(dailyConsumptionItem.getCategoryName())
+                .content(dailyConsumptionItem.getContent())
+                .amount(dailyConsumptionItem.getAmount())
+                .build();
+
+    }
+}

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.money_touch.domain.consumptionRecord.service;
 
 import com.server.money_touch.domain.consumptionRecord.converter.consumptionRecord.ConsumptionRecordConverter;
+import com.server.money_touch.domain.consumptionRecord.converter.household.HouseholdConsumptionConverter;
 import com.server.money_touch.domain.consumptionRecord.dto.HouseholdConsumptionResponse;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
@@ -169,12 +170,7 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
                 .findDailyConsumptionItemsWithCursor(userId, startOfDay, endOfDay, cursorId, cursorConsumeDate, PAGE_SIZE);
 
         List<HouseholdConsumptionResponse.ConsumeItemDTO> items = slice.getContent().stream()
-                .map(p -> HouseholdConsumptionResponse.ConsumeItemDTO.builder()
-                        .consumptionRecordId(p.getConsumptionRecordId())
-                        .categoryName(p.getCategoryName())
-                        .content(p.getContent())
-                        .amount(p.getAmount())
-                        .build())
+                .map(HouseholdConsumptionConverter::toConsumeItem)
                 .toList();
 
         Long nextCursorId = (slice.hasNext() && !items.isEmpty())

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
@@ -93,5 +93,4 @@ public class FixedConsumptionCommandServiceImpl implements FixedConsumptionComma
         fixedConsumptionRepository.delete(fixedConsumption);
         log.info("고정비 삭제 완료 - userId: {}, fixedConsumptionId: {}", userId, fixedConsumptionId);
     }
-
 }

--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
@@ -100,4 +100,12 @@ public class RoutineConverter {
                 .routineCategoryBudgets(routineCategoryBudgets)
                 .build();
     }
+
+    // 내 소비 루틴 상세 조회 DTO 변환
+    public static RoutineResponse.CategoryBudgetDetailDTO toCategoryBudgetDetailDTO(String categoryName, Integer amount) {
+        return RoutineResponse.CategoryBudgetDetailDTO.builder()
+                .categoryName(categoryName)
+                .amount(amount)
+                .build();
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
@@ -67,10 +67,7 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
 
         // 4. 카테고리 정보 DTO로 변환
         List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = routineAmounts.stream()
-                .map(ra -> RoutineResponse.CategoryBudgetDetailDTO.builder()
-                        .categoryName(ra.getCategoryName())
-                        .amount(ra.getAmount())
-                        .build())
+                .map(ra -> RoutineConverter.toCategoryBudgetDetailDTO(ra.getCategoryName(), ra.getAmount()))
                 .collect(Collectors.toList());
 
         log.info("내 소비 루틴 상세 조회 완료 - userId: {}, routeIneId: {}", userId, routineId);
@@ -110,7 +107,6 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
     }
 
     // 타인 소비 루틴 상세 조회
-    // 타인 소비 루틴 상세 조회
     @Override
     public RoutineResponse.RoutineListDetailDTO getOtherRoutineDetail(Long userId, Long routineId) {
         // 1. 루틴 조회
@@ -120,9 +116,8 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
         // 2. 루틴 금액 정보 조회
         List<RoutineAmount> routineAmounts = routineAmountRepository.findAllWithRoutineByRoutineId(routineId);
 
-        // 3. 금액이 0원 초과인 항목만 필터링 및 DTO 변환
+        // 3. 금액 필터링 없이 DTO 변환
         List<RoutineResponse.CategoryBudgetDetailDTO> categoryBudgetList = routineAmounts.stream()
-                .filter(ra -> ra.getAmount() != null && ra.getAmount() > 0)
                 .map(ra -> RoutineResponse.CategoryBudgetDetailDTO.builder()
                         .categoryName(ra.getCategoryName())
                         .amount(ra.getAmount())

--- a/src/main/java/com/server/money_touch/global/config/RedisConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/RedisConfig.java
@@ -12,6 +12,8 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
 @Configuration
 public class RedisConfig {
 
@@ -35,6 +37,7 @@ public class RedisConfig {
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30)) // ✅ TTL 설정 추가
                 .serializeKeysWith(RedisSerializationContext
                         .SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext

--- a/src/main/java/com/server/money_touch/global/test/RedisTestController.java
+++ b/src/main/java/com/server/money_touch/global/test/RedisTestController.java
@@ -3,6 +3,8 @@ package com.server.money_touch.global.test;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +13,11 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Redis 직접 명령(RedisTemplate) + Spring Cache(캐시 매니저) 모두 테스트 가능한 컨트롤러
+ * - /redis/set|get|exists|delete|ttl|expire: Redis 키-값 직접 확인
+ * - /redis/cache/*: Spring Cache 추상화를 통해 RedisCacheManager로 캐시 동작 확인
+ */
 @Tag(name = "redis-test-controller", description = "Redis Test(관리자용)")
 @Slf4j
 @RequiredArgsConstructor
@@ -18,8 +25,18 @@ import java.util.concurrent.TimeUnit;
 @RequestMapping("/redis")
 public class RedisTestController {
 
+    // Redis 문자열 명령을 직접 테스트하기 위한 템플릿
     private final RedisTemplate<String, String> redisTemplate;
 
+    // Spring Cache 추상화를 통한 동적 캐시 접근 (백엔드는 RedisCacheManager)
+    private final CacheManager cacheManager;
+
+    // -------------------- RedisTemplate 직접 테스트 --------------------
+
+    /**
+     * set key value [expireSeconds]
+     * expireSeconds가 지정되면 TTL과 함께 저장한다.
+     */
     @PostMapping("/set")
     public ResponseEntity<?> setValue(@RequestParam String key,
                                       @RequestParam String value,
@@ -32,11 +49,14 @@ public class RedisTestController {
             }
             return ResponseEntity.ok(Map.of("status", "success", "key", key, "value", value));
         } catch (Exception e) {
-            log.error("Redis SET 오류: {}", e.getMessage());
+            log.error("Redis SET 오류", e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
 
+    /**
+     * get key
+     */
     @GetMapping("/get")
     public ResponseEntity<?> getValue(@RequestParam String key) {
         try {
@@ -46,55 +66,149 @@ public class RedisTestController {
             }
             return ResponseEntity.ok(Map.of("key", key, "value", value));
         } catch (Exception e) {
-            log.error("Redis GET 오류: {}", e.getMessage());
+            log.error("Redis GET 오류", e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
 
+    /**
+     * EXISTS key
+     */
     @GetMapping("/exists")
     public ResponseEntity<?> checkExistence(@RequestParam String key) {
         try {
             boolean exists = Boolean.TRUE.equals(redisTemplate.hasKey(key));
             return ResponseEntity.ok(Map.of("key", key, "exists", exists));
         } catch (Exception e) {
-            log.error("Redis EXISTS 오류: {}", e.getMessage());
+            log.error("Redis EXISTS 오류", e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
 
+    /**
+     * DEL key
+     */
     @DeleteMapping("/delete")
     public ResponseEntity<?> deleteKey(@RequestParam String key) {
         try {
             Boolean deleted = redisTemplate.delete(key);
             return ResponseEntity.ok(Map.of("key", key, "deleted", deleted));
         } catch (Exception e) {
-            log.error("Redis DELETE 오류: {}", e.getMessage());
+            log.error("Redis DELETE 오류", e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
 
+    /**
+     * TTL key (초 단위)
+     * -2: 키 없음, -1: TTL 설정 없음
+     */
     @GetMapping("/ttl")
     public ResponseEntity<?> getTTL(@RequestParam String key) {
         try {
             Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
-            if (ttl == null || ttl < 0) {
-                return ResponseEntity.ok(Map.of("key", key, "ttl", "No expiration or key not found"));
+            if (ttl == null) {
+                return ResponseEntity.ok(Map.of("key", key, "ttl", "Unknown"));
+            }
+            if (ttl == -2) {
+                return ResponseEntity.status(404).body(Map.of("key", key, "ttl", "Key not found"));
+            }
+            if (ttl == -1) {
+                return ResponseEntity.ok(Map.of("key", key, "ttl", "No expiration"));
             }
             return ResponseEntity.ok(Map.of("key", key, "ttl_seconds", ttl));
         } catch (Exception e) {
-            log.error("Redis TTL 오류: {}", e.getMessage());
+            log.error("Redis TTL 오류", e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
 
+    /**
+     * EXPIRE key seconds
+     */
     @PostMapping("/expire")
     public ResponseEntity<?> expireKey(@RequestParam String key, @RequestParam Long seconds) {
         try {
             Boolean result = redisTemplate.expire(key, seconds, TimeUnit.SECONDS);
             return ResponseEntity.ok(Map.of("key", key, "expireSet", result));
         } catch (Exception e) {
-            log.error("Redis EXPIRE 오류: {}", e.getMessage());
+            log.error("Redis EXPIRE 오류", e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
+    }
+
+    // -------------------- Spring Cache(백엔드: Redis) 테스트 --------------------
+
+    /**
+     * 캐시에 값 조회. 미스일 경우 계산 후 캐시에 저장한다.
+     * cacheName은 동적으로 지정 가능하며, RedisCacheManager가 해당 이름의 캐시를 생성/사용한다.
+     * TTL/직렬화 등은 RedisCacheConfig에서 정의한 정책이 적용된다.
+     */
+    @GetMapping("/cache/get")
+    public ResponseEntity<?> getCachedValue(@RequestParam String cacheName,
+                                            @RequestParam String key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown cache: " + cacheName));
+        }
+
+        Cache.ValueWrapper hit = cache.get(key);
+        if (hit != null) {
+            return ResponseEntity.ok(Map.of("cache", cacheName, "key", key, "value", hit.get(), "hit", true));
+        }
+
+        // 캐시 미스: 계산 후 put
+        String computed = "ComputedValueFor_" + key;
+        cache.put(key, computed);
+        log.info("캐시 미스 -> 저장, cacheName={}, key={}", cacheName, key);
+        return ResponseEntity.ok(Map.of("cache", cacheName, "key", key, "value", computed, "hit", false));
+    }
+
+    /**
+     * 캐시 값 강제 갱신(put).
+     * 반환값이 아니라 cache.put을 직접 호출해 즉시 캐시를 덮어쓴다.
+     */
+    @PostMapping("/cache/update")
+    public ResponseEntity<?> updateCachedValue(@RequestParam String cacheName,
+                                               @RequestParam String key,
+                                               @RequestParam String value) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown cache: " + cacheName));
+        }
+        cache.put(key, value);
+        log.info("캐시 업데이트, cacheName={}, key={}, value={}", cacheName, key, value);
+        return ResponseEntity.ok(Map.of("cache", cacheName, "key", key, "updatedValue", value));
+    }
+
+    /**
+     * 캐시 엔트리 제거(evict).
+     * 특정 key만 제거한다.
+     */
+    @DeleteMapping("/cache/evict")
+    public ResponseEntity<?> evictCache(@RequestParam String cacheName,
+                                        @RequestParam String key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown cache: " + cacheName));
+        }
+        cache.evict(key);
+        log.info("캐시 삭제, cacheName={}, key={}", cacheName, key);
+        return ResponseEntity.ok(Map.of("cache", cacheName, "key", key, "cacheEvicted", true));
+    }
+
+    /**
+     * 캐시 전체 비우기(clear).
+     * 주의: 해당 cacheName의 모든 엔트리가 삭제된다.
+     */
+    @DeleteMapping("/cache/clear")
+    public ResponseEntity<?> clearCache(@RequestParam String cacheName) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown cache: " + cacheName));
+        }
+        cache.clear();
+        log.info("캐시 전체 삭제, cacheName={}", cacheName);
+        return ResponseEntity.ok(Map.of("cache", cacheName, "cleared", true));
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> ex) #119 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 타인의 소비 루틴 상세 조회 시 카테고리별 금액이 0원인 경우 응답을 반환하지 않는 오류 수정
- 가계부 관련 메서드에서 서비스 코드에서 직접 builder를 통해 응답 DTO를 사용하는 부분을 컨버터를 사용하도록 수정
- Redis Cache 테스트 메서드 추가 (아직 레디스 캐쉬를 다 이해하지 못해서,, 대강 만들어놨습니다.. 아마 도입하신다면 수정하셔야 될꺼에요)

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
3차 과제에 Redis 캐시를 도입할까 고민했는데, Redis 캐시는 데이터 변경이 잦지 않은 경우에 적합하다고 하더라고요. 예를 들어 소비 기록은 자주 생성되기 때문에, 이를 캐시에서 읽어오도록 하면 방금 등록한 소비 기록이 응답에 반영되지 않는 문제가 발생할 수 있습니다.
저희 API를 보니, Redis 캐시를 적용한다면 주 1회 정도만 업데이트되는 ‘소비왕 랭킹’이 가장 적합해 보입니다. 그런데 해당 메서드를 확인해 보니 이미 캐시를 사용하고 있는 것 같아서요. (캐시 수동 갱신 API가 있어서요)
그래서 ‘소비왕 랭킹’ 외에는 Redis 캐시를 도입하지 않는 것이 나을 것 같습니다. 대신, 3차 과제에서는 N+1 문제 해결 및 SQL 쿼리 최적화, 동시성 이슈 해결, 성능 테스트 및 개선 같은 항목을 진행하는 것이 좋을 것 같습니다.
이 부분은 각자 구현한 기능에서 최적화하는 성격이 강하니, 기능 구현이 완료된 분들은 3차 과제 항목 중에서 원하는 것을 하나씩 선택해 구현한 뒤, 노션에 정리하는 방식은 어떨까요? 아직 구현할 기능이 남으신 분들은 구현에 집중하시는게 더 좋을 것 같습니다!

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1112" height="460" alt="스크린샷 2025-08-09 오후 1 09 15" src="https://github.com/user-attachments/assets/d074cf4a-a40e-45b4-b28e-8135ba74e549" />  
타인의 소비 루틴 상세 조회 시, 카테고리별 금액이 0원인 경우도 같이 반환  

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
