### PR TITLE
fix: 소셜로그인 redirect Url 로직 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/user/controller/AuthController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/AuthController.java
@@ -37,8 +37,10 @@ public class AuthController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @GetMapping("/auth/login/kakao")
-    public ApiResponse<UserResponse.UserCreateResultDTO> kakaoLogin(@RequestParam("code") String accessCode, HttpServletResponse httpServletResponse) {
-        User user = authService.oAuthLogin(accessCode, httpServletResponse);
+    public ApiResponse<UserResponse.UserCreateResultDTO> kakaoLogin(@RequestParam("code") String accessCode, @RequestParam("redirectUri") String redirectUri,HttpServletResponse httpServletResponse) {
+        User user = authService.oAuthLogin(accessCode,redirectUri, httpServletResponse);
         return ApiResponse.onSuccess(UserConverter.toUserCreateResultDTO(user));
     }
+
+
 }

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -38,8 +38,11 @@ public class AuthService {
     private final BudgetCommandService budgetCommandService;
     private final TotalConsumptionRepository totalConsumptionRepository;
 
-    public User oAuthLogin(String accessCode, HttpServletResponse httpServletResponse) {
-        KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode);
+    public User oAuthLogin(String accessCode,String redirectUri, HttpServletResponse httpServletResponse) {
+        // 1. access token 요청 시 동적 redirectUri 전달
+        KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode, redirectUri);
+
+        // 2. 카카오 프로필 조회
         KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
         String email = kakaoProfile.getKakaoAccount().getEmail();
 

--- a/src/main/java/com/server/money_touch/domain/user/utils/KakaoUtil.java
+++ b/src/main/java/com/server/money_touch/domain/user/utils/KakaoUtil.java
@@ -22,21 +22,28 @@ import java.util.Arrays;
 public class KakaoUtil {
 
     @Value("${oauth.kakao.client-id}")
-    private String client;
-    @Value("${oauth.kakao.redirect-uri}")
-    private String redirect;
+    private String clientId;
 
-    public KakaoDTO.OAuthToken requestToken(String accessCode) {
+    public String buildAuthUrl(String dynamicRedirectUri) {
+        return "https://kauth.kakao.com/oauth/authorize"
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + dynamicRedirectUri;
+    }
+//    @Value("${oauth.kakao.redirect-uri}")
+//    private String redirect;
+
+    public KakaoDTO.OAuthToken requestToken(String accessCode, String redirectUri) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
-        params.add("client_id", client);
-        params.add("redirect_uri", redirect);
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri); // 동적 값
         params.add("code", accessCode);
-        log.info("client_id: {}, redirect_uri: {}", client, redirect);
+        log.info("client_id: {}, redirect_uri: {}", clientId, redirectUri);
         log.info("accessCode: {}", accessCode);
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#121 

## 📝 작업 내용
<img width="1367" height="748" alt="image" src="https://github.com/user-attachments/assets/32947294-183d-48f3-85a1-2cf8845c59c3" />
로그인시, 인가코드와 함께 redirect Url을 받아서 동적으로 Redirect Url을 설정합니다.


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

