### PR TITLE
✨feat: 이메일 인증 요청 api 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok' // Lombok 어노테이션 컴파일 시 처리
 
+	// SendGrid
+	implementation 'com.sendgrid:sendgrid-java:4.10.2'
+
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.server.money_touch.domain.user.service.user.UserQueryService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.utils.AuthUtil;
+import com.server.money_touch.global.utils.SendGridUtil;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExample;
 import com.server.money_touch.global.validation.annotation.ApiErrorCodeExamples;
 import com.server.money_touch.global.validation.annotation.ApiSuccessCodeExample;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 
 @Tag(name = "회원 가입 & 로그인 페이지", description = "유저에 관한 API")
@@ -31,6 +33,7 @@ import java.time.LocalDateTime;
 public class UserController{
 
     private final BadgeCommandService badgeCommandService;
+    private final SendGridUtil sendGridUtil;
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
     private final AuthUtil authUtil;
@@ -51,6 +54,25 @@ public class UserController{
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
         UserResponse.UserDetailCreateResultDTO response = userCommandService.saveUserDetails(userId, request);
         return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "이메일 인증 요청 API",
+            description = "sendgrid를 이용하여 이메일로 인증번호를 발송합니다."
+    )
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @GetMapping("/email")
+    public ApiResponse<String> requestEmail(@RequestParam("to") String toEmail) {
+        try {
+            sendGridUtil.sendEmail(toEmail);
+            return ApiResponse.onSuccess("인증 이메일이 발송되었습니다.");
+        } catch (IOException e) {
+            // 로그 기록 추가 가능
+            return ApiResponse.onFailure("SENDGRID4002","이메일 발송중 오류가 발생했습니다.", null);
+        }
     }
 
     @Operation(

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -59,6 +59,7 @@ public class UserResponse {
         private Long userId;
         private String accessToken;
         private String refreshToken;
+        private boolean isNewUser;
     }
 
     @Builder

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -88,6 +88,7 @@ public class AuthService {
                 .userId(user.getId())
                 .accessToken(tokenResponse.getAccessToken())
                 .refreshToken(tokenResponse.getRefreshToken())
+                .isNewUser(isNewUser)
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // SendGrid 관련에러
+    API_IS_NULL(HttpStatus.BAD_REQUEST, "SENDGRID4001", "Sendgrid api키가 null입니다."),
+
     // 유저 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "아이디와 일치하는 사용자가 없습니다."),
 

--- a/src/main/java/com/server/money_touch/global/config/SendGridConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SendGridConfig.java
@@ -1,0 +1,22 @@
+package com.server.money_touch.global.config;
+
+import com.sendgrid.SendGrid;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SendGridConfig {
+    @Value("${spring.sendgrid.api-key}")
+    private String apiKey;
+
+    @Bean
+    public SendGrid sendGrid() {
+        if (apiKey == null) {
+            throw new ErrorHandler(ErrorStatus.API_IS_NULL);
+        }
+        return new SendGrid(apiKey);
+    }
+}

--- a/src/main/java/com/server/money_touch/global/utils/SendGridUtil.java
+++ b/src/main/java/com/server/money_touch/global/utils/SendGridUtil.java
@@ -1,0 +1,67 @@
+package com.server.money_touch.global.utils;
+
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Random;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SendGridUtil {
+    private final SendGrid sendGrid;
+
+    @Value("${spring.sendgrid.from}")
+    private String fromEmail;
+
+    public String generateAuthCode() {
+        Random random = new Random();
+        int authCode = 100000 + random.nextInt(900000);  // 100000~999999 범위의 6자리 숫자 생성
+        return String.valueOf(authCode);
+    }
+
+
+    public void sendEmail(String toEmail) throws IOException {
+
+        // 보내는 사람 (발신자)
+        Email from = new Email(fromEmail);
+        // 제목
+        String subject = "💸돈터치 이메일 발송 안내";
+        // 받는 사람 (수신자)
+        Email to = new Email(toEmail);
+
+        String authCode = generateAuthCode();
+        Content content = new Content("text/plain", "인증번호: " + authCode);
+
+
+        // 발신자, 제목, 수신자, 내용을 합쳐 Mail 객체 생성
+        Mail mail = new Mail(from, subject, to, content);
+
+        send(mail);
+    }
+
+    private void send(Mail mail) throws IOException {
+        sendGrid.addRequestHeader("X-Mock", "true");
+
+        Request request = new Request();
+        request.setMethod(Method.POST);
+        request.setEndpoint("mail/send");
+        request.setBody(mail.build());
+
+        Response response = sendGrid.api(request);
+        log.info("SendGrid Response: {}", response.getStatusCode());
+        log.info("SendGrid Response: {}", response.getBody());
+        log.info("SendGrid Response: {}", response.getHeaders());
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#128 

## 📝 작업 내용
- 이메일 인증 요청 구현 
<img width="771" height="845" alt="image" src="https://github.com/user-attachments/assets/613ab438-99e7-485a-a129-1ce71003cd58" />
parameter에 이메일을 보내주면 해당 이메일로 인증번호가 전송됩니다.

## 📌 공유 사항
application.yml 수정해야합니다!
해당 부분은 문서에 수정해두도록하겠습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?