### PR TITLE
[#125] Fix: 소비 루틴 등록 시 동시성 이슈 추가 및 예산 등록 시 총 금액 필드 추가

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/converter/budget/BudgetConverter.java
+++ b/src/main/java/com/server/money_touch/domain/budget/converter/budget/BudgetConverter.java
@@ -23,9 +23,10 @@ public class BudgetConverter {
     }
 
     // Budget Entity → BudgetCreateResultDTO 변환
-    public static BudgetResponse.BudgetCreateResultDTO toBudgetCreateResultDto(Long budgetId) {
+    public static BudgetResponse.BudgetCreateResultDTO toBudgetCreateResultDto(Long budgetId, Integer totalBudget) {
         return BudgetResponse.BudgetCreateResultDTO.builder()
                 .budgetId(budgetId)
+                .totalBudget(totalBudget)
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
+++ b/src/main/java/com/server/money_touch/domain/budget/dto/BudgetResponse.java
@@ -16,6 +16,9 @@ public class BudgetResponse {
     public static class BudgetCreateResultDTO {
         @Schema(description = "예산 아이디", example = "1")
         private Long budgetId;
+
+        @Schema(description = "한 달 예산 금액", example = "5000000")
+        private Integer totalBudget;
     }
 
     @Builder

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budget/BudgetRepository.java
@@ -27,4 +27,7 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     Optional<Budget> findRegisteredBudgetInMonthNative(@Param("userId") Long userId,
                                                        @Param("start") LocalDateTime start,
                                                        @Param("end") LocalDateTime end);
+
+    // userId와 budgetId 모두 일치하는 예산 조회
+    Optional<Budget> findByIdAndUserId(Long budgetId, Long userId);
 }

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetCommandServiceImpl.java
@@ -127,7 +127,7 @@ public class BudgetCommandServiceImpl implements BudgetCommandService {
             log.info("예산 등록 완료 - userId: {}, budgetId: {}", user.getId(), budget.getId());
         }
 
-        return BudgetConverter.toBudgetCreateResultDto(budget.getId());
+        return BudgetConverter.toBudgetCreateResultDto(budget.getId(), budget.getBudgetTotal());
     }
 
     // 기본, 커스텀, 소비루틴 카테고리 수정

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/HouseholdConsumptionResponse.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/dto/HouseholdConsumptionResponse.java
@@ -69,7 +69,7 @@ public class HouseholdConsumptionResponse {
       "itemsSize": 1
     }
   ],
-  "dailyHistorySize": 3,
+  "monthlyHistorySize": 3,
   "isFirst": true,
   "isLast": false,
   "hasNext": false

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/projection/DailyConsumptionItemDetailProjection.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/projection/DailyConsumptionItemDetailProjection.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 // 달력 - 특정 날짜의 소비 내역 조회용 QueryDSL 프로젝션
 @Getter
 @Setter
@@ -15,5 +17,5 @@ public class DailyConsumptionItemDetailProjection {
     private String categoryName;
     private String content;
     private Integer amount;
-
+    private LocalDateTime consumeDate;
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -53,19 +54,19 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
             Long userId, LocalDateTime start, LocalDateTime end,
             Long cursorId, LocalDateTime cursorConsumeDate, int pageSize) {
 
-        // 기본 조건: 사용자 ID 일치 + 조회일 범위 내 소비 내역
+        // 기본 조건
         BooleanExpression baseCondition = record.user.id.eq(userId)
                 .and(record.consumeDate.between(start, end));
 
-        // 커서 조건: (consumeDate, id) 기준으로 이전 데이터 조회
+        // 커서 조건
         BooleanExpression cursorPredicate = null;
         if (cursorId != null && cursorConsumeDate != null) {
             cursorPredicate = record.consumeDate.lt(cursorConsumeDate)
                     .or(record.consumeDate.eq(cursorConsumeDate).and(record.id.lt(cursorId)));
         }
 
-        // 쿼리 실행: 필요한 컬럼만 projection으로 조회
-        List<DailyConsumptionItemDetailProjection> results = queryFactory
+        // 1) 1차 조회: pageSize + 1
+        List<DailyConsumptionItemDetailProjection> first = queryFactory
                 .select(Projections.fields(
                         DailyConsumptionItemDetailProjection.class,
                         record.id.as("consumptionRecordId"),
@@ -73,22 +74,70 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
                                 .when(record.isFixed.isTrue()).then("고정비")
                                 .otherwise(category.budgetCategoryName).as("categoryName"),
                         record.content,
-                        record.amount
+                        record.amount,
+                        record.consumeDate.as("consumeDate")    // ⚠ 경계 날짜 계산을 위해 포함
                 ))
                 .from(record)
                 .join(record.consumptionCategory, category)
-                .where(baseCondition.and(cursorPredicate)) // 기본 조건 + 커서 조건
-                .orderBy(record.consumeDate.desc(), record.id.desc()) // 최신순 정렬
-                .limit(pageSize + 1) // 다음 페이지 존재 여부 확인을 위한 +1
+                .where(baseCondition.and(cursorPredicate))
+                .orderBy(record.consumeDate.desc(), record.id.desc())
+                .limit(pageSize + 1)
                 .fetch();
 
-        // hasNext 판단 및 초과한 1개 제거
-        boolean hasNext = results.size() > pageSize;
-        if (hasNext) {
-            results.remove(results.size() - 1);
+        if (first.isEmpty()) {
+            return new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
         }
 
-        // SliceImpl로 반환 (Pageable은 의미상으로만 사용)
+        // 경계 날짜(boundaryDate)와 마지막 id
+        DailyConsumptionItemDetailProjection lastItem = first.get(Math.min(pageSize, first.size()) - 1);
+        LocalDateTime boundaryDate = lastItem.getConsumeDate();
+        Long boundaryLastId = lastItem.getConsumptionRecordId();
+
+        // 2) 경계 날짜의 '나머지' 모두 추가 조회 (해당 날짜이며 아직 포함되지 않은 더 작은 id들)
+        List<DailyConsumptionItemDetailProjection> extraSameDate = queryFactory
+                .select(Projections.fields(
+                        DailyConsumptionItemDetailProjection.class,
+                        record.id.as("consumptionRecordId"),
+                        Expressions.cases()
+                                .when(record.isFixed.isTrue()).then("고정비")
+                                .otherwise(category.budgetCategoryName).as("categoryName"),
+                        record.content,
+                        record.amount,
+                        record.consumeDate.as("consumeDate")
+                ))
+                .from(record)
+                .join(record.consumptionCategory, category)
+                .where(baseCondition
+                        .and(record.consumeDate.eq(boundaryDate))
+                        .and(record.id.lt(boundaryLastId)) // 아직 담지 않은 나머지
+                )
+                .orderBy(record.consumeDate.desc(), record.id.desc())
+                .fetch(); // 제한 없이 경계 날짜는 전부 가져온다
+
+        // 3) 결과 합치기: first의 앞부분(경계 이전까지) + extraSameDate
+        //   first는 pageSize + 1까지 가져왔으므로, 경계 이후의 초과 1개는 자동으로 정리됨
+        List<DailyConsumptionItemDetailProjection> results = new ArrayList<>();
+        // 경계 포함 이전까지 담기
+        results.addAll(first.subList(0, Math.min(pageSize, first.size())));
+        // 경계 날짜 나머지 모두 추가
+        results.addAll(extraSameDate);
+
+        // 4) hasNext 계산: 경계 날짜보다 더 오래된 데이터가 있는지 한 건 조회
+        DailyConsumptionItemDetailProjection nextProbe = queryFactory
+                .select(Projections.fields(
+                        DailyConsumptionItemDetailProjection.class,
+                        record.id.as("consumptionRecordId"),
+                        record.consumeDate.as("consumeDate")
+                ))
+                .from(record)
+                .where(baseCondition.and(record.consumeDate.lt(boundaryDate)))
+                .orderBy(record.consumeDate.desc(), record.id.desc())
+                .limit(1)
+                .fetchOne();
+
+        boolean hasNext = (nextProbe != null);
+
+        // Slice 반환 (Pageable은 의미상으로만 사용)
         return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
@@ -5,7 +5,10 @@ import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FixedConsumptionRepository extends JpaRepository<FixedConsumption, Long>, FixedConsumptionRepositoryCustom {
     List<FixedConsumption> findAllByUser(User user);
+
+    Optional<FixedConsumption> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
@@ -11,8 +11,8 @@ public interface FixedConsumptionCommandService {
 
     // 고정비 수정
     void updateFixedConsumption(
-            @ExistUser Long userId, @ExistFixedConsumption Long fixedConsumptionId, FixedConsumptionRequest.FixedConsumptionCreateDTO request);
+            @ExistUser Long userId, Long fixedConsumptionId, FixedConsumptionRequest.FixedConsumptionCreateDTO request);
 
     // 고정비 삭제
-    void deleteFixedConsumption(@ExistUser Long userId, @ExistFixedConsumption Long fixedConsumptionId);
+    void deleteFixedConsumption(@ExistUser Long userId, Long fixedConsumptionId);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
@@ -64,7 +64,7 @@ public class FixedConsumptionCommandServiceImpl implements FixedConsumptionComma
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 기존 고정비 조회 및 사용자 일치 확인
-        FixedConsumption fixedConsumption = fixedConsumptionRepository.findById(fixedConsumptionId)
+        FixedConsumption fixedConsumption = fixedConsumptionRepository.findByIdAndUserId(fixedConsumptionId, userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.FIXED_CONSUMPTION_NOT_FOUND));
 
         // 고정비 정보 수정
@@ -87,7 +87,7 @@ public class FixedConsumptionCommandServiceImpl implements FixedConsumptionComma
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 고정비 존재 여부 및 사용자 일치 확인
-        FixedConsumption fixedConsumption = fixedConsumptionRepository.findById(fixedConsumptionId)
+        FixedConsumption fixedConsumption = fixedConsumptionRepository.findByIdAndUserId(fixedConsumptionId, userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.FIXED_CONSUMPTION_NOT_FOUND));
 
         fixedConsumptionRepository.delete(fixedConsumption);

--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineAmountConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineAmountConverter.java
@@ -1,0 +1,18 @@
+package com.server.money_touch.domain.routine.converter;
+
+import com.server.money_touch.domain.routine.dto.RoutineRequest;
+import com.server.money_touch.domain.routine.entity.Routine;
+import com.server.money_touch.domain.routine.entity.RoutineAmount;
+
+public class RoutineAmountConverter {
+
+    // RoutineAmount 변환
+    public static RoutineAmount toRoutineAmount(RoutineRequest.CategoryBudgetDTO dto, Routine routine) {
+        return RoutineAmount.builder()
+                .categoryName(dto.getCategoryName())
+                .amount(dto.getAmount())
+                .routine(routine)
+                .build();
+    }
+
+}

--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
@@ -13,12 +13,13 @@ import java.util.List;
 
 public class RoutineConverter {
     // 루틴 엔티티 생성
-    public static Routine toRoutine(User user, Budget budget, RoutineRequest.RoutineCreateDTO routineCreateDTO) {
+    public static Routine toRoutine(User user, Budget budget, RoutineRequest.RoutineCreateDTO routineCreateDTO, String createdMonth) {
         return Routine.builder()
                 .user(user)
                 .budget(budget)
                 .routineName(routineCreateDTO.getRoutineName())
                 .routineImageUrl(routineCreateDTO.getRoutineImgUrl())
+                .createdMonth(createdMonth)
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -11,6 +11,14 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "unique_user_budget_month",
+                        columnNames = {"user_id", "budget_id", "created_month"}
+                )
+        }
+)
 public class Routine extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String routineName;
@@ -20,6 +28,10 @@ public class Routine extends BaseEntity {
 
     @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
     private Integer routineTotalAmount; // 소비 루틴 총 금액
+
+    // 생성일, "YYYY-MM" 형식으로 저장 (예: 2025-08)
+    @Column(name = "created_month", nullable = false, length = 7)
+    private String createdMonth;
 
     // 소비루틴-예산 다대일
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepository.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepository.java
@@ -1,16 +1,25 @@
 package com.server.money_touch.domain.routine.repository.routine;
 
 import com.server.money_touch.domain.routine.entity.Routine;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long>, RoutineRepositoryCustom {
-    // 이번달에 이미 등록된 소비 루틴이 있는지 검증
-    @Query("SELECT COUNT(r) > 0 FROM Routine r WHERE r.user.id = :userId AND MONTH(r.createdAt) = MONTH(CURRENT_DATE) AND YEAR(r.createdAt) = YEAR(CURRENT_DATE)")
-    boolean existsByUserIdInCurrentMonth(@Param("userId") Long userId);
-
+    // 현재 예산(budgetId)과 연월(createdMonth)에 해당하는 루틴이 존재하는지 확인 + PESSIMISTIC_WRITE 락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Routine r " +
+            "WHERE r.user.id = :userId " +
+            "AND r.budget.id = :budgetId " +
+            "AND r.createdMonth = :createdMonth")
+    Optional<Routine> findForUpdateByUserAndBudgetAndMonth(
+            @Param("userId") Long userId,
+            @Param("budgetId") Long budgetId,
+            @Param("createdMonth") String createdMonth
+    );
     Optional<Routine> findByIdAndUserId(Long routineId, Long userId);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepository.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long>, RoutineRepositoryCustom {
+
     // 현재 예산(budgetId)과 연월(createdMonth)에 해당하는 루틴이 존재하는지 확인 + PESSIMISTIC_WRITE 락
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM Routine r " +
@@ -21,5 +22,6 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
             @Param("budgetId") Long budgetId,
             @Param("createdMonth") String createdMonth
     );
+
     Optional<Routine> findByIdAndUserId(Long routineId, Long userId);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandService.java
@@ -8,7 +8,7 @@ import com.server.money_touch.global.validation.annotation.ExistUser;
 
 public interface RoutineCommandService {
     // 소비 루틴 등록
-    RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(@ExistUser Long userId, @ExistBudget Long budgetId, RoutineRequest.RoutineCreateDTO request);
+    RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(@ExistUser Long userId, Long budgetId, RoutineRequest.RoutineCreateDTO request);
 
     // 타인의 소비 루틴을 내 예산에 반영
     void applyRoutineToBudget(@ExistUser Long userId, @ExistBudget Long budgetId, @ExistRoutine Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request);

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -92,8 +92,15 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         }
 
         // 7. 루틴 저장
+        //   - 동시에 같은 (user, budget, createdMonth) 조합이 저장되는 경쟁 상황 방지
+        //   - 유니크 제약 위반 발생 시 DataIntegrityViolationException을 잡아 예외 변환
         Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
-        routineRepository.save(routine);
+        try {
+            routineRepository.save(routine);
+        } catch (DataIntegrityViolationException e) {
+            // 혹시 경쟁 상황으로 유니크 제약 위반 시
+            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+        }
 
         // 8. RoutineAmount 저장
         List<RoutineAmount> routineAmounts = request.getBudgetList().stream()

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -5,8 +5,10 @@ import com.server.money_touch.domain.budget.entity.Budget;
 import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
 import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.converter.consumptionCategory.ConsumptionCategoryConverter;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
+import com.server.money_touch.domain.routine.converter.RoutineAmountConverter;
 import com.server.money_touch.domain.routine.converter.RoutineConverter;
 import com.server.money_touch.domain.routine.converter.RoutineHashtagConverter;
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
@@ -24,6 +26,7 @@ import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -51,60 +54,54 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
     private final RoutineAmountRepository routineAmountRepository;
 
     // 소비 루틴 등록
-    // RoutineServiceImpl.java
-
     @Transactional
     @Override
-    public RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(Long userId, Long budgetId, RoutineRequest.RoutineCreateDTO request) {
+    public RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(
+            Long userId,
+            Long budgetId,
+            RoutineRequest.RoutineCreateDTO request) {
         // 1. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 1-1. 이미 이번 달에 등록된 루틴이 있는지 확인
-        if (routineRepository.existsByUserIdInCurrentMonth(userId)) {
+        // 2. 예산 조회
+        Budget budget = budgetRepository.findByIdAndUserId(budgetId, userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
+
+        // 3. 예산의 createdMonth로 이번 달 판단
+        String createdMonth = budget.getCreatedMonth();
+
+        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (PESSIMISTIC_WRITE)
+        if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
             throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
         }
 
-        // 2. 카테고리 총합 계산
+        // 5. 카테고리 총합 계산
         int totalCategoryBudget = Optional.ofNullable(request.getBudgetList())
                 .orElse(List.of())
                 .stream()
                 .mapToInt(RoutineRequest.CategoryBudgetDTO::getAmount)
                 .sum();
 
-        // 3. 예산 총액과 일치 여부 확인
+        // 6. 예산 총액과 일치 여부 확인
         if (totalCategoryBudget > request.getTotalBudget()) {
-            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_EXCEEDED); // 총액 초과
+            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_EXCEEDED);
         }
         if (totalCategoryBudget < request.getTotalBudget()) {
-            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_TOO_LOW); // 총액 미달
+            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_TOO_LOW);
         }
 
-        // 4. 예산 존재 여부 확인 (예산과 관련된 데이터는 수정하지 않도록 구현 -> PM님 답변 오는거 보고 수정)
-        Budget budget = budgetRepository.findById(budgetId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
-
-        // 5. 소비 루틴 저장
-        Routine routine = Routine.builder()
-                .routineName(request.getRoutineName())
-                .routineImageUrl(request.getRoutineImgUrl())
-                .routineTotalAmount(request.getTotalBudget())
-                .budget(budget)
-                .user(user)
-                .build();
+        // 7. 루틴 저장
+        Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
         routineRepository.save(routine);
 
-        // 6. RoutineAmount 저장
+        // 8. RoutineAmount 저장
         List<RoutineAmount> routineAmounts = request.getBudgetList().stream()
-                .map(dto -> RoutineAmount.builder()
-                        .categoryName(dto.getCategoryName())
-                        .amount(dto.getAmount())
-                        .routine(routine)
-                        .build()
-                ).collect(Collectors.toList());
+                .map(dto -> RoutineAmountConverter.toRoutineAmount(dto, routine))
+                .collect(Collectors.toList());
         routineAmountRepository.saveAll(routineAmounts);
 
-        // 7. 해시태그 저장
+        // 9. 해시태그 저장
         if (request.getHashtags() != null) {
             List<RoutineHashtag> hashtags = request.getHashtags().stream()
                     .map(tag -> RoutineHashtagConverter.toRoutineHashtag(routine, tag))
@@ -112,89 +109,9 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             routineHashtagRepository.saveAll(hashtags);
         }
 
-        // 8. 결과 DTO 반환
-        Long routineId = routine.getId();
-        log.info("소비 루틴 등록 완료 - userId: {}, routineId: {}", userId, routineId);
-        return RoutineConverter.toRoutineCreateResultDTO(routineId);
+        // 10. 결과 반환
+        return RoutineConverter.toRoutineCreateResultDTO(routine.getId());
     }
-
-
-//    @Transactional
-//    @Override
-//    public RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(Long userId, Long budgetId, RoutineRequest.RoutineCreateDTO request) {
-//        // 1. 사용자 조회
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
-//
-//        // 1-1. 이미 이번 달에 등록된 루틴이 있는지 확인
-//        if (routineRepository.existsByUserIdInCurrentMonth(userId)) {
-//            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
-//        }
-//
-//        // 2. 카테고리 총합 계산
-//        int totalCategoryBudget = Optional.ofNullable(request.getBudgetList())
-//                .orElse(List.of())
-//                .stream()
-//                .mapToInt(RoutineRequest.CategoryBudgetDTO::getAmount)
-//                .sum();
-//
-//        // 3. 예산 총액과 일치 여부 확인
-//        if (totalCategoryBudget > request.getTotalBudget()) {
-//            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_EXCEEDED); // 총액 초과
-//        }
-//        if (totalCategoryBudget < request.getTotalBudget()) {
-//            throw new ErrorHandler(ErrorStatus.TOTAL_BUDGET_TOO_LOW); // 총액 미달
-//        }
-//
-//        // 4. 예산 조회 및 예산 총액/루틴 여부 수정
-//        Budget budget = budgetRepository.findById(budgetId)
-//                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
-//        budget.updateTotalBudget(request.getTotalBudget());
-//
-//        // 5. 요청된 카테고리 이름 → 금액 맵핑
-//        Map<String, Integer> requestMap = request.getBudgetList().stream()
-//                .collect(Collectors.toMap(RoutineRequest.CategoryBudgetDTO::getCategoryName, RoutineRequest.CategoryBudgetDTO::getAmount));
-//
-//        // 6. 해당 예산에 연결된 예산 카테고리 + 소비 카테고리 조회
-//        List<BudgetCategory> budgetCategories = budgetCategoryRepository.findAllByBudgetIdWithCategory(budgetId);
-//
-//        // 7. categoryName → BudgetCategory 맵핑
-//        Map<String, BudgetCategory> budgetCategoryMap = budgetCategories.stream()
-//                .collect(Collectors.toMap(
-//                        bc -> bc.getConsumptionCategory().getBudgetCategoryName(),
-//                        Function.identity()
-//                ));
-//
-//        // 8. 요청 기준으로 비교 후 금액 수정 or 새로 생성
-//        for (Map.Entry<String, Integer> entry : requestMap.entrySet()) {
-//            String categoryName = entry.getKey();
-//            Integer amount = entry.getValue();
-//
-//            BudgetCategory category = budgetCategoryMap.get(categoryName);
-//
-//            if (category != null) {
-//                if (!category.getBudgetCategoryMoney().equals(amount)) {
-//                    category.updateAmount(amount);
-//                }
-//            } else {
-//                // 존재하지 않는 경우 CUSTOM 타입 소비 카테고리 및 예산 카테고리 생성
-//                ConsumptionCategory newCategory = ConsumptionCategory.builder()
-//                        .budgetCategoryName(categoryName)
-//                        .budgetCategoryType(CategoryType.CUSTOM)
-//                        .user(user)
-//                        .build();
-//
-//                ConsumptionCategory savedCategory = consumptionCategoryRepository.save(newCategory);
-//
-//                BudgetCategory newBudgetCategory = BudgetCategory.builder()
-//                        .budget(budget)
-//                        .consumptionCategory(savedCategory)
-//                        .budgetCategoryMoney(amount)
-//                        .build();
-//
-//                budgetCategoryRepository.save(newBudgetCategory);
-//            }
-//        }
 
     // 타인의 소비 루틴을 내 예산에 반영
     @Transactional
@@ -278,11 +195,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
 
                     } else {
                         // ✅ 기존 항목이 없는 경우 → 새로 생성
-                        ConsumptionCategory newCategory = ConsumptionCategory.builder()
-                                .user(user)
-                                .budgetCategoryName(name)
-                                .budgetCategoryType(requestType)
-                                .build();
+                        ConsumptionCategory newCategory = ConsumptionCategoryConverter.toConsumptionCategory(user, name, requestType);
                         consumptionCategoryRepository.save(newCategory);
 
                         BudgetCategory newBudgetCategory = BudgetCategoryConverter.toBudgetCategory(budget, newCategory, amount);

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -36,7 +36,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOTAL_BUDGET_TOO_LOW(HttpStatus.BAD_REQUEST, "BUDGET4003", "카테고리 예산 총합이 전체 예산보다 작습니다."),
     BUDGET_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "BUDGET4004", "한 달 예산 등록 횟수를 초과하였습니다."),
     BUDGET_NOT_EXIST(HttpStatus.NOT_FOUND, "BUDGET_4041", "이번달에 등록된 예산이 없습니다."),
-    ROUTINE_CATEGORY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BUDGET_403", "소비 루틴 카테고리는 소비 루틴을 등록한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 설정할 수 있습니다."),
+    ROUTINE_CATEGORY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BUDGET4005", "소비 루틴 카테고리는 소비 루틴을 등록한 경우나, 타인의 소비 루틴을 내 예산에 반영한 경우만 설정할 수 있습니다."),
     BUDGE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "BUDGET4011", "접근 권한이 없는 예산 아이디입니다. 예산 아이디 조회를 통해 올바른 예산 아이디로 구성해주세요."),
 
     // 소비 MBTI 관련 에러


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #125

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 소비 루틴 등록 시 동시성 이슈 추가 (유니크 제약, 비관적 락)
- 예산 등록 시 총 금액 필드 추가

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
