### PR TITLE
✨feat: 이메일 인증 확인 api구현 완료

### DIFF
--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController{
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
     })
-    @GetMapping("/email")
+    @GetMapping("/email/send")
     public ApiResponse<String> requestEmail(@RequestParam("to") String toEmail) {
         try {
             userQueryService.requestEmailVerification(toEmail);
@@ -72,6 +72,21 @@ public class UserController{
         } catch (IOException e) {
             // 로그 기록 추가 가능
             return ApiResponse.onFailure("SENDGRID4002","이메일 발송중 오류가 발생했습니다.", null);
+        }
+    }
+    @Operation(summary = "이메일 인증 확인 API"
+    ,description = "이메일 인증을 요청한 인증번호를 검증하는 API입니다.")
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @GetMapping("/email/verify")
+    public ApiResponse<String> verifyAuthCode(@RequestParam String email, @RequestParam String code) {
+        boolean isValid = sendGridUtil.verifyAuthCode(email, code);
+        if (isValid) {
+            return ApiResponse.onSuccess("인증이 완료되었습니다.");
+        } else {
+            return ApiResponse.onFailure("INVALID_CODE", "인증번호가 올바르지 않거나 만료되었습니다.", null);
         }
     }
 

--- a/src/main/java/com/server/money_touch/global/config/RedisConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -25,6 +26,17 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.password}")
     private String password;
+
+
+    // RedisTemplate을 사용해서 인증번호를 저장하고 가져올 수 있도록 설정
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {

--- a/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 STATELESS 상태로 설정
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers(
-                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email", "/api/consumptionMbti/save", // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
+                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email/send","/api/user/email/verify", "/api/consumptionMbti/save",  // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
                                 "/", "/index.html", "/css/**", "/js/**", "/images/**", "/actuator/health", // Spring Boot의 정적 리소스 기본 경로 및 test
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", // Swaggger 문서
                                 "/api/test/s3/upload") // 프로필 이미지 업로드

--- a/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 STATELESS 상태로 설정
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers(
-                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email", // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
+                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email", "/api/consumptionMbti/save", // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
                                 "/", "/index.html", "/css/**", "/js/**", "/images/**", "/actuator/health", // Spring Boot의 정적 리소스 기본 경로 및 test
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", // Swaggger 문서
                                 "/api/test/s3/upload") // 프로필 이미지 업로드

--- a/src/main/java/com/server/money_touch/global/utils/SendGridUtil.java
+++ b/src/main/java/com/server/money_touch/global/utils/SendGridUtil.java
@@ -10,16 +10,19 @@ import com.sendgrid.helpers.mail.objects.Email;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class SendGridUtil {
     private final SendGrid sendGrid;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${spring.sendgrid.from}")
     private String fromEmail;
@@ -40,14 +43,23 @@ public class SendGridUtil {
         // 받는 사람 (수신자)
         Email to = new Email(toEmail);
 
+        // 인증번호 생성
         String authCode = generateAuthCode();
+
+        // Redis에 저장 (5분 TTL)
+        String redisKey = "emailAuth:" + toEmail;
+        redisTemplate.opsForValue().set(redisKey, authCode, 5, TimeUnit.MINUTES);
+
+        // 로그 출력 (인증코드 저장 확인)
+        String savedCode = redisTemplate.opsForValue().get(redisKey);
+        log.info("✅ Redis 저장 완료 - key: {}, value: {}", redisKey, savedCode);
+
         Content content = new Content("text/plain", "인증번호: " + authCode);
-
-
-        // 발신자, 제목, 수신자, 내용을 합쳐 Mail 객체 생성
         Mail mail = new Mail(from, subject, to, content);
 
         send(mail);
+
+
     }
 
     private void send(Mail mail) throws IOException {
@@ -62,6 +74,22 @@ public class SendGridUtil {
         log.info("SendGrid Response: {}", response.getStatusCode());
         log.info("SendGrid Response: {}", response.getBody());
         log.info("SendGrid Response: {}", response.getHeaders());
+    }
+
+    public boolean verifyAuthCode(String toEmail, String inputCode) {
+        String redisKey = "emailAuth:" + toEmail;
+        String savedCode = redisTemplate.opsForValue().get(redisKey);
+
+        // 로그로 현재 Redis 값 확인
+        log.info("🔍 Redis 조회 - key: {}, value: {}", redisKey, savedCode);
+
+        if (savedCode != null && savedCode.equals(inputCode)) {
+            // 인증 성공 시 Redis 키 삭제
+            redisTemplate.delete(redisKey);
+            log.info("🗑️ Redis 키 삭제 완료 - key: {}", redisKey);
+            return true;
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#128 

## 📝 작업 내용
<img width="736" height="633" alt="image" src="https://github.com/user-attachments/assets/02a5fe5c-dff3-4601-b108-48e9435a4403" />
발송한 이메일과 인증번호를 redis에 저장하고, 해당부분을 비교하여 인증결과를 응답으로 보내줍니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?
