### PR TITLE
[#136] 🐛Fix: 특정 월의 일일 소비 내역 조회 시 고정비 오류 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryCustom.java
@@ -23,8 +23,9 @@ public interface ConsumptionRecordRepositoryCustom {
             int limit);
 
     // 경계 날짜(boundary date)의 나머지 데이터를 추가 조회.
-    List<DailyConsumptionItemProjection> findRestOfBoundaryDate(
+    List<DailyConsumptionItemProjection> findRestOfBoundaryDateClampedToMonth(
             Long userId,
+            LocalDateTime monthStart, LocalDateTime monthEnd,
             LocalDateTime boundaryStart, LocalDateTime boundaryEnd,
             Long minIncludedId);
 

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepositoryImpl.java
@@ -115,19 +115,20 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
      *
      * @param userId             조회할 사용자 ID
      * @param monthStart         월 시작일(LocalDateTime, 00:00)
-     * @param monthEnd           월 종료일(LocalDateTime, 23:59:59)
+     * @param nextMonthStart     다음달 시작일(LocalDateTime, 00:00)  // ⚠️ 상한은 '미만'으로 사용할 것
      * @param cursorConsumeDate  커서로 사용할 기준 소비일시 (null이면 첫 페이지)
      * @param limit              조회할 데이터 개수(페이지 사이즈)
      * @return DailyConsumptionItemProjection 목록
      */
     @Override
     public List<DailyConsumptionItemProjection> findChunkByMonthUsingDateCursor(
-            Long userId, LocalDateTime monthStart, LocalDateTime monthEnd,
+            Long userId, LocalDateTime monthStart, LocalDateTime nextMonthStart,
             LocalDateTime cursorConsumeDate, int limit) {
 
-        // 기본 조건: 해당 사용자 + 지정한 월 범위 내 소비내역
+        // ✅ 월 범위를 [monthStart, nextMonthStart) 로 '반열린 구간'으로 고정
         BooleanExpression base = record.user.id.eq(userId)
-                .and(record.consumeDate.between(monthStart, monthEnd));
+                .and(record.consumeDate.goe(monthStart))
+                .and(record.consumeDate.lt(nextMonthStart));
 
         // 날짜 커서 조건: 다음 페이지는 cursorConsumeDate의 '자정'보다 이전 데이터만 조회
         BooleanExpression dateCursor = null;
@@ -162,15 +163,20 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
      *   같은 날짜의 나머지 데이터를 모두 가져오기 위해 호출됨
      * - minIncludedId보다 오래된(더 작은) ID 데이터만 조회하여 중복 방지
      *
-     * @param userId        조회할 사용자 ID
-     * @param boundaryStart 경계 날짜의 시작 시간 (00:00)
-     * @param boundaryEnd   경계 날짜의 종료 시간 (23:59:59)
-     * @param minIncludedId 현재 페이지에서 이미 포함된 가장 오래된 데이터의 ID
+     * @param userId            조회할 사용자 ID
+     * @param monthStart        월 시작일(LocalDateTime, 00:00)
+     * @param nextMonthStart    다음달 시작일(LocalDateTime, 00:00) // ⚠️ 상한 미만
+     * @param boundaryStart     경계 날짜의 시작 시간 (00:00)
+     * @param boundaryEnd       경계 날짜의 종료 시간 (23:59:59.999999999)
+     * @param minIncludedId     현재 페이지에서 이미 포함된 가장 오래된 데이터의 ID
      * @return DailyConsumptionItemProjection 목록
      */
     @Override
-    public List<DailyConsumptionItemProjection> findRestOfBoundaryDate(
-            Long userId, LocalDateTime boundaryStart, LocalDateTime boundaryEnd, Long minIncludedId) {
+    public List<DailyConsumptionItemProjection> findRestOfBoundaryDateClampedToMonth(
+            Long userId,
+            LocalDateTime monthStart, LocalDateTime nextMonthStart,
+            LocalDateTime boundaryStart, LocalDateTime boundaryEnd,
+            Long minIncludedId) {
 
         return queryFactory
                 .select(Projections.fields(
@@ -178,8 +184,13 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
                         record.id.as("consumptionRecordId"),
                         record.consumeDate.as("consumeDate"),
                         Expressions.cases()
-                                .when(record.isFixed.isTrue()).then("고정비")
-                                .otherwise(category.budgetCategoryName).as("categoryName"),
+                                // ✅ 고정비라도 consumeDate가 월 범위 안인 경우만 "고정비" (표시용)
+                                .when(record.isFixed.isTrue()
+                                        .and(record.consumeDate.goe(monthStart))
+                                        .and(record.consumeDate.lt(nextMonthStart)))
+                                .then("고정비")
+                                .otherwise(category.budgetCategoryName)
+                                .as("categoryName"),
                         record.content,
                         record.amount
                 ))
@@ -187,6 +198,10 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
                 .leftJoin(record.consumptionCategory, category)
                 .where(
                         record.user.id.eq(userId)
+                                // ✅ 월 범위 [monthStart, nextMonthStart)
+                                .and(record.consumeDate.goe(monthStart))
+                                .and(record.consumeDate.lt(nextMonthStart))
+                                // ✅ 하루 범위
                                 .and(record.consumeDate.between(boundaryStart, boundaryEnd))
                                 .and(record.id.lt(minIncludedId))
                 )
@@ -199,23 +214,18 @@ public class ConsumptionRecordRepositoryImpl implements ConsumptionRecordReposit
      *
      * - 다음 페이지가 있는지 여부를 판단하는 데 사용
      * - boundaryStart 이전에 데이터가 존재하면 true 반환
-     *
-     * @param userId        조회할 사용자 ID
-     * @param monthStart    월 시작일(LocalDateTime, 00:00)
-     * @param monthEnd      월 종료일(LocalDateTime, 23:59:59)
-     * @param boundaryStart 비교 기준이 되는 날짜(LocalDateTime, 00:00)
-     * @return 존재 여부 (true: 데이터 있음, false: 데이터 없음)
      */
     @Override
     public boolean existsOlderThanDate(
-            Long userId, LocalDateTime monthStart, LocalDateTime monthEnd, LocalDateTime boundaryStart) {
+            Long userId, LocalDateTime monthStart, LocalDateTime nextMonthStart, LocalDateTime boundaryStart) {
 
         Long probe = queryFactory
                 .select(record.id)
                 .from(record)
                 .where(
                         record.user.id.eq(userId)
-                                .and(record.consumeDate.between(monthStart, monthEnd))
+                                .and(record.consumeDate.goe(monthStart))
+                                .and(record.consumeDate.lt(nextMonthStart)) // ✅ 반열린 구간
                                 .and(record.consumeDate.lt(boundaryStart))
                 )
                 .limit(1)

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordQueryServiceImpl.java
@@ -63,14 +63,19 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
         return ConsumptionRecordConverter.toDailyConsumptionDetailDTO(consumptionRecord, consumptionCategory);
     }
 
-    // 해당 월의 소비 내역 목록 조회 (커서 기반 무한스크롤)
-    // - 요구사항: 페이지 사이즈와 관계없이 "특정 날짜의 데이터가 여러 페이지에 분리되지 않도록" 보장.
-    // - 전략:
-    //   1) (consumeDate DESC, id DESC) 기준으로 pageSize+1개를 가져와 "경계 날짜(boundaryDate)"를 결정
-    //   2) 경계 날짜가 잘릴 위험이 있으므로, 경계 날짜의 "나머지 전부"를 추가 쿼리로 모아 합치기
-    //   3) 다음 페이지 존재 여부는 "경계 날짜보다 과거 데이터가 있는가"로 판정
-    //   4) nextCursorId는 "이번에 내려준 마지막(가장 오래된) 아이템의 id"로 반환
-    //      (레포에서 커서를 '날짜 기준'으로만 쓰도록 수정하면, 같은 날짜 재등장 이슈가 사라집니다)
+    /**
+     * 해당 월의 소비 내역 목록 조회 (커서 기반 무한스크롤)
+     * - 요구사항: 페이지 사이즈와 관계없이 "특정 날짜의 데이터가 여러 페이지에 분리되지 않도록" 보장.
+     * - 핵심 규칙: 월 범위는 반드시 [monthStart, nextMonthStart) 반열린 구간으로 통일 (상한 미만)
+     *
+     * 전략:
+     *   1) (consumeDate DESC, id DESC) 기준으로 pageSize+1개를 가져와 "경계 날짜(boundaryDate)"를 결정
+     *   2) 경계 날짜가 잘릴 위험이 있으므로, 경계 날짜의 "나머지 전부"를 추가 쿼리로 모아 합치기
+     *      - 이때도 월 범위를 [monthStart, nextMonthStart)로 강제(클램핑)하여 월 넘김 혼입 방지
+     *   3) 다음 페이지 존재 여부는 "경계 날짜보다 과거 데이터가 있는가"로 판정
+     *   4) nextCursorId는 "이번에 내려준 마지막(가장 오래된) 아이템의 id"로 반환
+     *      (레포에서 커서를 '날짜 기준'으로만 쓰도록 하면, 같은 날짜가 다음 페이지에 재등장하지 않음)
+     */
     @Override
     public HouseholdConsumptionResponse.MonthlyHistoryResponseDTO getMonthlyConsumptionRecords(
             Long userId, int year, int month, Long cursorId) {
@@ -79,14 +84,14 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
         userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 1) 해당 월 범위
-        LocalDate startDate = LocalDate.of(year, month, 1);
-        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
-        LocalDateTime monthStart = startDate.atStartOfDay();
-        LocalDateTime monthEnd = endDate.atTime(23, 59, 59, 999_999_999);
+        // 1) 해당 월 범위 계산
+        //    ⚠️ 월 범위는 반드시 [monthStart, nextMonthStart) 로 사용 (상한 미만)
+        LocalDate firstDay = LocalDate.of(year, month, 1);
+        LocalDateTime monthStart = firstDay.atStartOfDay();                 // ex) 2025-07-01 00:00
+        LocalDateTime nextMonthStart = firstDay.plusMonths(1).atStartOfDay(); // ex) 2025-08-01 00:00
 
         // 2) 커서의 consumeDate 조회 (id → consumeDate)
-        //    다음 페이지는 "이 날짜보다 과거(< dayStart)"만 보도록 만들 것이므로
+        //    다음 페이지는 "이 날짜의 0시보다 과거(< dayStart)"만 보도록 만들 것이므로
         //    레포지토리에서 id 커서 비교(= 같은 날짜에서 id<...)는 사용하지 않게 해야 "날짜 쪼개짐"이 사라집니다.
         LocalDateTime cursorConsumeDate = null;
         if (cursorId != null) {
@@ -100,11 +105,17 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
         //      즉, "날짜만" 기준으로 다음 페이지를 자르도록 해야 같은 날짜 재등장이 없음.
         final int pageSize = PAGE_SIZE; // 기존 상수 재사용
         List<DailyConsumptionItemProjection> chunk = consumptionRecordRepository
-                .findChunkByMonthUsingDateCursor(userId, monthStart, monthEnd, cursorConsumeDate, pageSize + 1);
+                .findChunkByMonthUsingDateCursor(
+                        userId,
+                        monthStart,            // ✅ 하한: 포함
+                        nextMonthStart,        // ✅ 상한: 미만
+                        cursorConsumeDate,
+                        pageSize + 1
+                );
 
         if (chunk.isEmpty()) {
             return ConsumptionRecordConverter.toMonthlyHistoryResponseDTO(
-                    List.of(), true, false, null
+                    List.of(), /*isFirst*/ true, /*hasNext*/ false, /*nextCursorId*/ null
             );
         }
 
@@ -114,9 +125,19 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
         int visibleCount = Math.min(pageSize, chunk.size());
         List<DailyConsumptionItemProjection> visible = new ArrayList<>(chunk.subList(0, visibleCount));
 
-        LocalDate boundaryDate = visible.get(visible.size() - 1).getConsumeDate().toLocalDate();
-        LocalDateTime boundaryStart = boundaryDate.atStartOfDay();
-        LocalDateTime boundaryEnd = boundaryStart.plusDays(1).minusNanos(1);
+        LocalDate boundaryDate = visible.get(visibleCount - 1).getConsumeDate().toLocalDate();
+        LocalDateTime boundaryStart = boundaryDate.atStartOfDay();                  // ex) 2025-07-31 00:00
+        LocalDateTime boundaryEnd = boundaryStart.plusDays(1).minusNanos(1);       // ex) 2025-07-31 23:59:59.999999999
+
+        // 4-1) 경계 날짜 구간도 월 경계를 넘지 않도록 '클램핑'
+        //      - 하한은 monthStart 이상
+        //      - 상한은 nextMonthStart 미만
+        LocalDateTime boundaryStartClamped = boundaryStart.isBefore(monthStart) ? monthStart : boundaryStart;
+        LocalDateTime boundaryEndClampedExclusive = boundaryEnd.plusNanos(1); // [start, end] → [start, endExclusive)
+        LocalDateTime boundaryEndClampedExclusiveFinal =
+                boundaryEndClampedExclusive.isAfter(nextMonthStart) ? nextMonthStart : boundaryEndClampedExclusive;
+        // 최종적으로 between 용으로 다시 [start, end] 포함구간으로 변환
+        LocalDateTime boundaryEndClamped = boundaryEndClampedExclusiveFinal.minusNanos(1);
 
         // 5) 경계 날짜의 나머지 아이템 전부 추가 조회
         //    - chunk는 pageSize 제한 때문에 "경계 날짜의 일부"만 담겼을 수 있음
@@ -127,8 +148,13 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
                 .min(Long::compareTo) // 정렬이 DESC이므로 "가장 오래된 id"가 min
                 .orElse(Long.MAX_VALUE);
 
-        List<DailyConsumptionItemProjection> extraSameDate = consumptionRecordRepository
-                .findRestOfBoundaryDate(userId, boundaryStart, boundaryEnd, minIncludedIdOnBoundary);
+        List<DailyConsumptionItemProjection> extraSameDate =
+                consumptionRecordRepository.findRestOfBoundaryDateClampedToMonth(
+                        userId,
+                        monthStart, nextMonthStart,           // ✅ 월 범위 [monthStart, nextMonthStart)
+                        boundaryStartClamped, boundaryEndClamped, // ✅ 하루 범위도 월에 클램핑
+                        minIncludedIdOnBoundary
+                );
 
         // 6) 결과 합치기 (정렬 유지: consumeDate DESC, id DESC)
         //    - visible(앞부분) + extraSameDate(경계 날짜 나머지) 순으로 합칩니다.
@@ -137,7 +163,9 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
         merged.addAll(extraSameDate);
 
         // 7) hasNext 계산: 경계 날짜보다 과거 데이터가 있는지
-        boolean hasNext = consumptionRecordRepository.existsOlderThanDate(userId, monthStart, monthEnd, boundaryStart);
+        boolean hasNext = consumptionRecordRepository.existsOlderThanDate(
+                userId, monthStart, nextMonthStart, boundaryStartClamped
+        );
 
         // 8) nextCursorId: 이번에 내려준 리스트 중 "가장 오래된" 아이템의 id (마지막 요소)
         Long nextCursorId = hasNext && !merged.isEmpty()
@@ -238,6 +266,5 @@ public class ConsumptionRecordQueryServiceImpl implements ConsumptionRecordQuery
                 nextCursorId,
                 isFirst
         );
-
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
@@ -3,11 +3,13 @@ package com.server.money_touch.domain.fixedConsumption.repository;
 import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FixedConsumptionRepository extends JpaRepository<FixedConsumption, Long>, FixedConsumptionRepositoryCustom {
+    @Query("select distinct fc from FixedConsumption fc where fc.user = :user")
     List<FixedConsumption> findAllByUser(User user);
 
     Optional<FixedConsumption> findByIdAndUserId(Long id, Long userId);


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #136 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 특정 월의 일일 소비 내역 조회 시 8월달의 고정비가 7월달 내역에서 조회되는 오류 수정
- 고정비 스케줄링 등록에서 유저의 고정비 조회 시 중복을 막기 위해 쿼리에 `distinct` 추가

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1041" height="435" alt="스크린샷 2025-08-11 오후 8 43 15" src="https://github.com/user-attachments/assets/c6b18832-81c9-4033-8896-b09b793002ba" />  
8월달 내역 조회 시 고정비


<img width="1047" height="423" alt="스크린샷 2025-08-11 오후 8 45 09" src="https://github.com/user-attachments/assets/5c6aa377-2ea3-4131-a2ba-80c5c0b1e908" />  
7월달 내역에는 고정비가 없기 때문에 내역에서 보이지 않음



## 💬 리뷰 요구사항 (선택)
