### PR TITLE
🐛Fix: 소비 루틴 엔티티 생성 시 routineTotalAmount 누락 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/server/money_touch/domain/routine/converter/RoutineConverter.java
@@ -17,6 +17,7 @@ public class RoutineConverter {
         return Routine.builder()
                 .user(user)
                 .budget(budget)
+                .routineTotalAmount(routineCreateDTO.getTotalBudget())
                 .routineName(routineCreateDTO.getRoutineName())
                 .routineImageUrl(routineCreateDTO.getRoutineImgUrl())
                 .createdMonth(createdMonth)


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> X

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 소비 루틴 등록 시 `Routine` 엔티티 생성 시 컨버터에서 `routineTotalAmount`가 누락되어 소비 루틴 등록이 되지 않는 오류 수정
<img width="2436" height="418" alt="image" src="https://github.com/user-attachments/assets/16d8de91-cd0d-4724-bf57-cbca88caaaa9" />


## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1074" height="567" alt="스크린샷 2025-08-11 오후 10 24 23" src="https://github.com/user-attachments/assets/0d77f3e5-8d52-4f0b-b04e-6ef189514f09" />  
소비 루틴 등록 성공

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
