### PR TITLE
🐛fix : 이메일 재전송 로직 추가

### DIFF
--- a/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/money_touch/domain/user/controller/UserController.java
@@ -66,9 +66,9 @@ public class UserController{
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
     })
     @GetMapping("/email/send")
-    public ApiResponse<String> requestEmail(@RequestParam("to") String toEmail) {
+    public ApiResponse<String> requestEmail(@RequestParam("to") String toEmail, @RequestParam boolean isResend) {
         try {
-            userQueryService.requestEmailVerification(toEmail);
+            userQueryService.requestEmailVerification(toEmail, isResend);
             return ApiResponse.onSuccess("인증 이메일이 발송되었습니다.");
         } catch (IOException e) {
             // 로그 기록 추가 가능

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -4,10 +4,7 @@ import com.server.money_touch.domain.budget.entity.Budget;
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
 import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
-import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
 import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
-import com.server.money_touch.domain.user.converter.AuthConverter;
-import com.server.money_touch.domain.user.converter.UserConverter;
 import com.server.money_touch.domain.user.dto.KakaoDTO;
 import com.server.money_touch.domain.user.dto.TokenResponse;
 import com.server.money_touch.domain.user.dto.UserResponse;
@@ -96,9 +93,11 @@ public class AuthService {
     public User createNewUser(KakaoDTO.KakaoProfile kakaoProfile) {
         String email = kakaoProfile.getKakaoAccount().getEmail();
         String kakaoKey = String.valueOf(kakaoProfile.getId());
+        String nickname = kakaoProfile.getKakaoAccount().getProfile().getNickname();
 
         // 1. User 생성
         User newUser = User.builder()
+                .nickname(nickname)
                 .email(email)
                 .authType(AuthType.KAKAO)
                 .role(Role.USER)

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryService.java
@@ -15,7 +15,7 @@ public interface UserQueryService {
     Boolean existsByNickname(String nickname);
 
     // 이메일 요청및 이메일 중복 검증
-    void requestEmailVerification(String toEmail)throws IOException;
+    void requestEmailVerification(String toEmail, boolean isResend)throws IOException;
 
     // 마이페이지 유저 정보 조회
     UserResponse.MyPageResponseDTO getMyPageInfo(Long userId);

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
@@ -44,14 +44,14 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     // 이메일 인증번호 발송
-    public void requestEmailVerification(String toEmail) throws IOException {
+    public void requestEmailVerification(String toEmail, boolean isResend) throws IOException {
         // 이메일 중복 체크
         if (existsByEmail(toEmail)) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
 
         // 이메일 발송
-        sendGridUtil.sendEmail(toEmail);
+        sendGridUtil.sendEmail(toEmail, isResend);
     }
 
     // 마이페이지

--- a/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 STATELESS 상태로 설정
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers(
-                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email/send","/api/user/email/verify", "/api/consumptionMbti/save",  // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
+                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email/send","/api/user/email/verify", "/api/consumptionMbti/save", "/api/user/delete",  // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
                                 "/", "/index.html", "/css/**", "/js/**", "/images/**", "/actuator/health", // Spring Boot의 정적 리소스 기본 경로 및 test
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", // Swaggger 문서
                                 "/api/test/s3/upload") // 프로필 이미지 업로드

--- a/src/main/java/com/server/money_touch/global/utils/SendGridUtil.java
+++ b/src/main/java/com/server/money_touch/global/utils/SendGridUtil.java
@@ -34,28 +34,31 @@ public class SendGridUtil {
     }
 
 
-    public void sendEmail(String toEmail) throws IOException {
+    public void sendEmail(String toEmail, boolean isResend) throws IOException {
 
-        // 보내는 사람 (발신자)
-        Email from = new Email(fromEmail);
-        // 제목
-        String subject = "💸돈터치 이메일 발송 안내";
-        // 받는 사람 (수신자)
-        Email to = new Email(toEmail);
+        String redisKey = "emailAuth:" + toEmail;
+
+        // 재전송이면 기존 인증번호 삭제
+        if (isResend && redisTemplate.hasKey(redisKey)) {
+            redisTemplate.delete(redisKey);
+            log.info("♻ 기존 인증번호 삭제 완료 - key: {}", redisKey);
+        }
 
         // 인증번호 생성
         String authCode = generateAuthCode();
 
-        // Redis에 저장 (5분 TTL)
-        String redisKey = "emailAuth:" + toEmail;
-        redisTemplate.opsForValue().set(redisKey, authCode, 5, TimeUnit.MINUTES);
+        // TTL 설정 (최초 발송 5분, 재발송 3분)
+        long ttlMinutes = isResend ? 3 : 5;
+        redisTemplate.opsForValue().set(redisKey, authCode, ttlMinutes, TimeUnit.MINUTES);
+        log.info("✅ 인증번호 저장 완료 - key: {}, value: {}, TTL: {}분", redisKey, authCode, ttlMinutes);
 
-        // 로그 출력 (인증코드 저장 확인)
-        String savedCode = redisTemplate.opsForValue().get(redisKey);
-        log.info("✅ Redis 저장 완료 - key: {}, value: {}", redisKey, savedCode);
-
+        // 메일 발송
+        Email from = new Email(fromEmail);
+        Email to = new Email(toEmail);
+        String subject = isResend ? "💸 돈터치 이메일 인증번호 재전송 안내" : "💸 돈터치 이메일 발송 안내";
         Content content = new Content("text/plain", "인증번호: " + authCode);
         Mail mail = new Mail(from, subject, to, content);
+
 
         send(mail);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#128 

## 📝 작업 내용
<img width="604" height="398" alt="image" src="https://github.com/user-attachments/assets/294d05fa-ee68-4579-92bb-79feec7f172c" />

- 이메일로 인증번호를 전송후, 재전송에 대한 로직을 추가하였습니다.
- Security Config에 회원삭제를 permitall에 추가하였습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?