### PR TITLE
🐛fix: 소셜로그인, 회원삭제 로직 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Comment.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/Comment.java
@@ -42,4 +42,7 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> replies = new ArrayList<>();
 
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -60,6 +60,12 @@ public class ConsumptionRecord extends BaseEntity {
     @Builder.Default
     private Boolean isFixed = false; // 고정비 여부
 
+    @OneToMany(mappedBy = "consumptionRecord", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Reaction> reactions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "consumptionRecord", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
     // 일일 소비 기록 수정
     public void updateDailyConsumptionRecord(ConsumptionCategory category, int amount, String content, String memo, LocalDateTime consumeDate) {
         this.consumptionCategory = category;

--- a/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/server/money_touch/domain/user/dto/UserResponse.java
@@ -71,6 +71,7 @@ public class UserResponse {
         private Long userId;
         private String accessToken;
         private String refreshToken;
+        private String nickname;
         private boolean isNewUser;
     }
 

--- a/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
+++ b/src/main/java/com/server/money_touch/domain/user/repository/user/UserRepository.java
@@ -12,6 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u LEFT JOIN FETCH u.userDetail")
     List<User> findAllWithUserDetail();
 
+    // 닉네임 중복 검증
     Boolean existsByNickname(String nickname);
 
     // email로 유저 조회

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -14,6 +14,8 @@ import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.enums.AuthType;
 import com.server.money_touch.domain.user.enums.Role;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
+import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
+import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.global.config.jwt.TokenProvider;
 import com.server.money_touch.domain.user.utils.KakaoUtil;
 import jakarta.servlet.http.HttpServletResponse;
@@ -94,6 +96,11 @@ public class AuthService {
         String email = kakaoProfile.getKakaoAccount().getEmail();
         String kakaoKey = String.valueOf(kakaoProfile.getId());
         String nickname = kakaoProfile.getKakaoAccount().getProfile().getNickname();
+
+        // 닉네임 중복 체크
+        if (userRepository.existsByNickname(nickname)) {
+            throw new ErrorHandler(ErrorStatus.NICKNAME_ALREADY_EXISTS);
+        }
 
         // 1. User 생성
         User newUser = User.builder()

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -85,6 +85,7 @@ public class AuthService {
 
         return UserResponse.OAuthLoginResultDTO.builder()
                 .userId(user.getId())
+                .nickname(user.getNickname())
                 .accessToken(tokenResponse.getAccessToken())
                 .refreshToken(tokenResponse.getRefreshToken())
                 .isNewUser(isNewUser)

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserQueryServiceImpl.java
@@ -45,6 +45,7 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     // 이메일 인증번호 발송
     public void requestEmailVerification(String toEmail, boolean isResend) throws IOException {
+
         // 이메일 중복 체크
         if (existsByEmail(toEmail)) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");

--- a/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/money_touch/global/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 유저 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "아이디와 일치하는 사용자가 없습니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4002", "이미 존재하는 닉네임입니다."),
+
 
     // 유저 상세정보 관련 에러
     ALREADY_REGISTERED_USER_DETAIL(HttpStatus.BAD_REQUEST,"DETAIL4001", "이미 유저 상세정보가 등록되어 있습니다."),

--- a/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
+++ b/src/main/java/com/server/money_touch/global/config/SecurityConfig.java
@@ -30,7 +30,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 STATELESS 상태로 설정
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers(
-                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**", "/api/user/nickname", "/api/user/email/send","/api/user/email/verify", "/api/consumptionMbti/save", "/api/user/delete",  // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
+                                "/api/user/signup/local", "/api/user/login/local","/auth/login/kakao/**",  // 로그인, 회원가입, 이메일 요청, 닉네임 중복 확인
+                                "/api/user/nickname", "/api/consumptionMbti/save", "/api/user/delete", // 닉네임 중복 확인, MBTI 업로드, 회원 삭제
+                                "/api/user/email/send","/api/user/email/verify",                       // 이메일 인증 요청, 인증 확인
                                 "/", "/index.html", "/css/**", "/js/**", "/images/**", "/actuator/health", // Spring Boot의 정적 리소스 기본 경로 및 test
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", // Swaggger 문서
                                 "/api/test/s3/upload") // 프로필 이미지 업로드


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#121 

## 📝 작업 내용
- 소셜로그인시, 응답으로 nickname을 보내주도록 추가
- 회원 삭제를 위해, 엔티티끼리 cascade추가(comment, commentlike, consumptionrecord)
- 소셜 회원가입시, 닉네임 중복시 에러 띄어주도록 추가


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?