### PR TITLE
[#142] ⚙️ Chore: 소비 루틴 한 달 등록 횟수 제한 임시 해제 

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -11,14 +11,14 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-@Table(
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "unique_user_budget_month",
-                        columnNames = {"user_id", "budget_id", "created_month"}
-                )
-        }
-)
+//@Table(
+//        uniqueConstraints = {
+//                @UniqueConstraint(
+//                        name = "unique_user_budget_month",
+//                        columnNames = {"user_id", "budget_id", "created_month"}
+//                )
+//        }
+//)
 public class Routine extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String routineName;
@@ -26,7 +26,7 @@ public class Routine extends BaseEntity {
     @Column(nullable = false)
     private String routineImageUrl;
 
-    @Column(columnDefinition = "INT DEFAULT 0",  nullable = false)
+    @Column(columnDefinition = "INT DEFAULT 0")
     private Integer routineTotalAmount; // 소비 루틴 총 금액
 
     // 생성일, "YYYY-MM" 형식으로 저장 (예: 2025-08)

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -71,10 +71,10 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         // 3. 예산의 createdMonth로 이번 달 판단
         String createdMonth = budget.getCreatedMonth();
 
-        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (PESSIMISTIC_WRITE)
-        if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
-            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
-        }
+//        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (PESSIMISTIC_WRITE)
+//        if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
+//            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+//        }
 
         // 5. 카테고리 총합 계산
         int totalCategoryBudget = Optional.ofNullable(request.getBudgetList())
@@ -92,15 +92,19 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         }
 
         // 7. 루틴 저장
-        //   - 동시에 같은 (user, budget, createdMonth) 조합이 저장되는 경쟁 상황 방지
-        //   - 유니크 제약 위반 발생 시 DataIntegrityViolationException을 잡아 예외 변환
         Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
-        try {
-            routineRepository.save(routine);
-        } catch (DataIntegrityViolationException e) {
-            // 혹시 경쟁 상황으로 유니크 제약 위반 시
-            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
-        }
+        routineRepository.save(routine);
+
+//        // 7. 루틴 저장
+//        //   - 동시에 같은 (user, budget, createdMonth) 조합이 저장되는 경쟁 상황 방지
+//        //   - 유니크 제약 위반 발생 시 DataIntegrityViolationException을 잡아 예외 변환
+//        Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
+//        try {
+//            routineRepository.save(routine);
+//        } catch (DataIntegrityViolationException e) {
+//            // 혹시 경쟁 상황으로 유니크 제약 위반 시
+//            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+//        }
 
         // 8. RoutineAmount 저장
         List<RoutineAmount> routineAmounts = request.getBudgetList().stream()


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #142 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 프론트분 요청에 따라 소비 루틴 등록의 월 1회 제한을 임시로 해제했습니다. 이에 맞춰 DB 유니크 제약을 삭제하고 저장 로직을 수정했습니다.
- 연동 완료되면 다시 소비 루틴 등록은 월 1회만 가능하도록 코드 수정하겠습니다.

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  연동 때문에 해제하는거라 로컬에서는 유니크 조건을 삭제하지 않으셔도 될 것 같습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
