### PR TITLE
[#146] 🐛Fix: 일일 소비 기록 등록 시 isPublic false로 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class ConsumptionRecordConverter {
 
     // 일일 소비 기록 시 소비 카테고리 엔티티 생성
-    public static ConsumptionRecord toDailyConsumptionRecord(User user, ConsumptionCategory consumptionCategory, HouseholdConsumptionRequest.DailyConsumptionCreateDTO requestDTO) {
+    public static ConsumptionRecord toDailyConsumptionRecord(User user, ConsumptionCategory consumptionCategory, HouseholdConsumptionRequest.DailyConsumptionCreateDTO requestDTO, Boolean isPublic) {
         return ConsumptionRecord.builder()
                 .user(user)
                 .consumptionCategory(consumptionCategory)
@@ -26,7 +26,7 @@ public class ConsumptionRecordConverter {
                 .content(requestDTO.getContent())
                 .memo(requestDTO.getMemo())
                 .consumeDate(requestDTO.getConsumeDate())
-                .isPublic(true) // 가계부에만 등록
+                .isPublic(isPublic) // 일일 소비 기록은 피드 없이 가계부에만 등록
                 .commentCount(0)
                 .wiseCount(0)
                 .wasteCount(0)

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordCommandServiceImpl.java
@@ -48,7 +48,7 @@ public class ConsumptionRecordCommandServiceImpl implements ConsumptionRecordCom
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.CONSUMPTION_CATEGORY_NAME_NOT_FOUND));
 
         // 3. 소비 기록 엔티티 생성
-        ConsumptionRecord dailyConsumptionRecord = ConsumptionRecordConverter.toDailyConsumptionRecord(user, consumptionCategory, request);
+        ConsumptionRecord dailyConsumptionRecord = ConsumptionRecordConverter.toDailyConsumptionRecord(user, consumptionCategory, request, false);
         consumptionRecordRepository.save(dailyConsumptionRecord);
 
         // 4-1. 현재 연도와 월 기준으로 월 시작일과 종료일 계산


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #146 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 일일 소비 기록 등록 시 피드 없이 가계부에만 등록되어야 하기 때문에 `ConsumptionRecord` 테이블의 `isPublic` 필드를 true-> false로 수정

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="487" height="251" alt="스크린샷 2025-08-15 오후 10 19 26" src="https://github.com/user-attachments/assets/dae7955f-57f3-400d-8820-ce464e1e1262" />
<img width="1398" height="90" alt="스크린샷 2025-08-15 오후 10 20 51" src="https://github.com/user-attachments/assets/274f5843-28ea-4523-8631-2be130a1227a" />


## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
> X