### PR TITLE
[#148] ⚙️Chore: 소비 루틴 한 달 1회 등록 제한 재적용

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -11,14 +11,14 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-//@Table(
-//        uniqueConstraints = {
-//                @UniqueConstraint(
-//                        name = "unique_user_budget_month",
-//                        columnNames = {"user_id", "budget_id", "created_month"}
-//                )
-//        }
-//)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "unique_user_budget_month",
+                        columnNames = {"user_id", "budget_id", "created_month"}
+                )
+        }
+)
 public class Routine extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String routineName;

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -92,19 +92,15 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         }
 
         // 7. 루틴 저장
+        //   - 동시에 같은 (user, budget, createdMonth) 조합이 저장되는 경쟁 상황 방지
+        //   - 유니크 제약 위반 발생 시 DataIntegrityViolationException을 잡아 예외 변환
         Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
-        routineRepository.save(routine);
-
-//        // 7. 루틴 저장
-//        //   - 동시에 같은 (user, budget, createdMonth) 조합이 저장되는 경쟁 상황 방지
-//        //   - 유니크 제약 위반 발생 시 DataIntegrityViolationException을 잡아 예외 변환
-//        Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
-//        try {
-//            routineRepository.save(routine);
-//        } catch (DataIntegrityViolationException e) {
-//            // 혹시 경쟁 상황으로 유니크 제약 위반 시
-//            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
-//        }
+        try {
+            routineRepository.save(routine);
+        } catch (Exception e) {
+            // 혹시 경쟁 상황으로 유니크 제약 위반 시
+            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+        }
 
         // 8. RoutineAmount 저장
         List<RoutineAmount> routineAmounts = request.getBudgetList().stream()


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
>- #148 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 연동으로 인해 일시적으로 해제했던 소비 루틴 등록의 월 1회 제한을 다시 적용하도록 수정
- 기존 소비 루틴 데이터가 유니크 제약 조건에 위배되어 제약 조건 추가가 불가능해, 우선 트리거를 통해 소비 루틴을 월 1회만 등록 가능하도록 수정했습니다. 관련 데이터는 데모데이 전까지 최대한 정리하겠습니다.

유니크 제약 조건 대신 설정해 놓은 소비 루틴 월 1회 등록 제한 트리거
```
DELIMITER //
CREATE TRIGGER routine_no_dup
BEFORE INSERT ON routine
FOR EACH ROW
BEGIN
  IF EXISTS (
    SELECT 1 FROM routine
    WHERE user_id = NEW.user_id
      AND budget_id = NEW.budget_id
      AND created_month = NEW.created_month
  ) THEN
    SIGNAL SQLSTATE '45000'
      SET MESSAGE_TEXT = 'Duplicate entry not allowed';
  END IF;
END;
//
DELIMITER ;
```

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1084" height="543" alt="스크린샷 2025-08-18 오후 10 26 29" src="https://github.com/user-attachments/assets/e4c97e62-834b-407f-bee0-3fe2b7bd2423" />


## 💬 리뷰 요구사항 (선택)
X
