### PR TITLE
[#150] 🐛Fix: 한 달 총 소비 금액 조회 시 소비 기록 합계 금액과 일치하지 않는 오류 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -7,7 +7,7 @@ import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
 import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
-import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
 import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 public class BudgetQueryServiceImpl implements BudgetQueryService {
     private final BudgetRepository budgetRepository;
     private final BudgetCategoryRepository budgetCategoryRepository;
-    private final TotalConsumptionRepository totalConsumptionRepository;
+    private final ConsumptionRecordRepository consumptionRecordRepository;
     private final UserRepository userRepository;
 
     // 예산 존재 여부 검증
@@ -89,29 +89,25 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
     }
 
     // 예산 아이디 및 총 소비 금액 조회
-    @Transactional
+    @Transactional(readOnly = true)
     @Override
     public BudgetResponse.TotalConsumptionResultDTO findBudgetByIdAndTotalConsumption(Long userId, Integer year, Integer month) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 해당 월의 시작일과 종료일 계산
+        // 예산 조회 기간(예산 id 조회는 기존 로직 유지)
         LocalDateTime startOfMonth = LocalDate.of(year, month, 1).atStartOfDay();
         LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
 
-        // 총 소비 금액 조회 (없으면 0으로 처리)
-        TotalConsumption totalConsumption = totalConsumptionRepository
-                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElse(null);
+        // 총 소비 금액: consumption_record에서 직접 합계
+        Integer totalAmount = consumptionRecordRepository.sumMonthlyAmountByUser(userId, year, month);
+        if (totalAmount == null) totalAmount = 0;
 
-        int totalAmount = (totalConsumption != null) ? totalConsumption.getTotalConsumptionAmount() : 0;
-
-        // 예산 조회 (없으면 budgetId = null)
-        // 회원가입 및 1일에 데이터가 생성되기 때문에 createdAt과 updatedAt이 같으면 아직 사용자가 직접 등록하지 않은 예산으로 간주
+        // 해당 월에 사용자가 직접 등록한 예산 조회
         Budget budget = budgetRepository.findRegisteredBudgetInMonthNative(userId, startOfMonth, endOfMonth)
                 .orElse(null);
-
         Long budgetId = (budget != null) ? budget.getId() : null;
+
         log.info("예산 아이디 및 총 소비 금액 조회 - userId: {}, budgetId: {}", userId, budgetId);
         return BudgetConverter.toTotalConsumptionResultDto(budgetId, totalAmount);
     }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
@@ -4,6 +4,7 @@ import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,4 +20,19 @@ public interface ConsumptionRecordRepository extends JpaRepository<ConsumptionRe
     WHERE cr.user = :user AND cr.consumeDate BETWEEN :start AND :end
     GROUP BY cr.consumptionCategory.budgetCategoryName """)
     List<Object[]> findCategorySpendingBetween(User user, LocalDateTime start, LocalDateTime end);
+
+    // 이번 달 총 소비 금액 조회
+    @Query(
+            value = "SELECT COALESCE(SUM(amount), 0) " +
+                    "FROM consumption_record " +
+                    "WHERE user_id = :userId " +
+                    "AND MONTH(consume_date) = :month " +
+                    "AND YEAR(consume_date) = :year",
+            nativeQuery = true
+    )
+    Integer sumMonthlyAmountByUser(
+            @Param("userId") Long userId,
+            @Param("year") Integer year,
+            @Param("month") Integer month
+    );
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordCommandServiceImpl.java
@@ -33,7 +33,6 @@ public class ConsumptionRecordCommandServiceImpl implements ConsumptionRecordCom
     private final ConsumptionRecordRepository consumptionRecordRepository;
     private final ConsumptionCategoryRepository consumptionCategoryRepository;
     private final UserRepository userRepository;
-    private final TotalConsumptionRepository totalConsumptionRepository;
 
     // 일일 소비 기록 등록
     @Transactional
@@ -50,18 +49,6 @@ public class ConsumptionRecordCommandServiceImpl implements ConsumptionRecordCom
         // 3. 소비 기록 엔티티 생성
         ConsumptionRecord dailyConsumptionRecord = ConsumptionRecordConverter.toDailyConsumptionRecord(user, consumptionCategory, request, false);
         consumptionRecordRepository.save(dailyConsumptionRecord);
-
-        // 4-1. 현재 연도와 월 기준으로 월 시작일과 종료일 계산
-        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
-        // 4-2. 해당 월의 총 소비 금액 조회, 데이터가 없다면 생성
-        TotalConsumption totalConsumption = totalConsumptionRepository
-                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseGet(() -> totalConsumptionRepository.save(TotalConsumptionConverter.toTotalConsumption(user)));
-
-        // 4-3. 소비 금액 추가
-        totalConsumption.updateAddTotalConsumptionAmount(request.getAmount());
 
         Long consumptionRecordId = dailyConsumptionRecord.getId();
         log.info("일일 소비 기록 등록 완료: userId: {}, consumptionRecordId: {}", userId, consumptionRecordId);
@@ -84,19 +71,7 @@ public class ConsumptionRecordCommandServiceImpl implements ConsumptionRecordCom
         ConsumptionCategory consumptionCategory = consumptionCategoryRepository.findByUserAndBudgetCategoryName(user, request.getCategoryName())
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.CONSUMPTION_CATEGORY_NAME_NOT_FOUND));
 
-        // 4-1. 현재 연도와 월 기준으로 월 시작일과 종료일 계산
-        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
-        // 4-2. 해당 월의 총 소비 금액 조회, 데이터가 없다면 에러
-        TotalConsumption totalConsumption = totalConsumptionRepository
-                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseThrow(() -> new IllegalArgumentException("총 소비 정보가 존재하지 않습니다. 관리자에게 문의해 주세요."));
-
-        // 4-3. 총 소비 금액 수정
-        totalConsumption.updateTotalConsumptionAmount(consumptionRecord.getAmount(), request.getAmount());
-
-        // 5. 일일 소비 기록 수정
+        // 4. 일일 소비 기록 수정
         consumptionRecord.updateDailyConsumptionRecord(consumptionCategory, request.getAmount(), request.getContent(),request.getMemo(), request.getConsumeDate());
 
         log.info("일일 소비 기록 수정 완료 - userId: {}, consumptionRecordId: {}", userId, consumptionRecordId);
@@ -114,19 +89,7 @@ public class ConsumptionRecordCommandServiceImpl implements ConsumptionRecordCom
         ConsumptionRecord consumptionRecord = consumptionRecordRepository.findById(consumptionRecordId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.CONSUMPTION_RECORD_NOT_FOUND));
 
-        // 3-1. 현재 연도와 월 기준으로 월 시작일과 종료일 계산
-        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
-        // 3-2. 해당 월의 총 소비 금액 조회, 데이터가 없다면 에러
-        TotalConsumption totalConsumption = totalConsumptionRepository
-                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseThrow(() -> new IllegalArgumentException("총 소비 정보가 존재하지 않습니다. 관리자에게 문의해 주세요."));
-
-        // 3-3. 총 소비 금액 차감
-        totalConsumption.updateSubstractTotalConsumptionAmount(consumptionRecord.getAmount());
-
-        // 6. 소비 기록 삭제
+        // 3. 소비 기록 삭제
         consumptionRecordRepository.delete(consumptionRecord);
 
         log.info("일일 소비 기록 삭제 완료 - userId: {}, consumptionRecordId: {}", userId, consumptionRecordId);

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/service/ConsumptionRecordServiceImpl.java
@@ -87,18 +87,6 @@ public class ConsumptionRecordServiceImpl implements ConsumptionRecordService{
             consumptionRecordImageRepository.save(image);
         }
 
-        // 4-1. 현재 연도와 월 기준으로 월 시작일과 종료일 계산
-        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
-        // 4-2. 해당 월의 총 소비 금액 조회, 데이터가 없다면 생성
-        TotalConsumption totalConsumption = totalConsumptionRepository
-                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseGet(() -> totalConsumptionRepository.save(TotalConsumptionConverter.toTotalConsumption(user)));
-
-        // 4-3. 소비 금액 추가
-        totalConsumption.updateAddTotalConsumptionAmount(request.getAmount());
-
         return new ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO(record.getId());
 
     }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
@@ -36,7 +36,6 @@ public class FixedConsumptionSchedulerService {
     private final FixedConsumptionRepository fixedConsumptionRepository;
     private final ConsumptionCategoryRepository consumptionCategoryRepository;
     private final ConsumptionRecordRepository consumptionRecordRepository;
-    private final TotalConsumptionRepository totalConsumptionRepository;
     private final BudgetCommandService budgetCommandService;
 
     /**
@@ -61,26 +60,18 @@ public class FixedConsumptionSchedulerService {
     public void processUserFixedConsumption(User user) {
         try {
             LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-            LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
 
             // 1. Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
             Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
             budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
 
-            // 2. TotalConsumption 조회 or 생성
-            TotalConsumption totalConsumption = totalConsumptionRepository
-                    .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                    .orElseGet(() -> totalConsumptionRepository.save(
-                            TotalConsumptionConverter.toTotalConsumption(user))
-                    );
-
-            // 3. 기본 ConsumptionCategory 목록 불러오기 (카테고리 이름 기준 매핑)
+            // 2. 기본 ConsumptionCategory 목록 불러오기 (카테고리 이름 기준 매핑)
             Map<String, ConsumptionCategory> categoryMap = consumptionCategoryRepository
                     .findAllByUserAndBudgetCategoryType(user, CategoryType.DEFAULT)
                     .stream()
                     .collect(Collectors.toMap(ConsumptionCategory::getBudgetCategoryName, c -> c));
 
-            // 4~6. 고정비 목록을 기반으로 소비 기록 생성 및 저장 + TotalConsumption 반영
+            // 3. 고정비 목록을 기반으로 소비 기록 생성 및 저장 + TotalConsumption 반영
             fixedConsumptionRepository.findAllByUser(user).stream()
                     .map(fc -> {
                         String categoryName = fc.getCategoryName();
@@ -92,11 +83,6 @@ public class FixedConsumptionSchedulerService {
 
                         // 소비 기록 생성
                         ConsumptionRecord record = ConsumptionRecordConverter.toConsumptionRecordForFix(user, category, fc, startOfMonth);
-
-                        // TotalConsumption 금액 반영
-                        totalConsumption.updateAddTotalConsumptionAmount(fc.getFixedConsumptionAmount());
-                        totalConsumptionRepository.save(totalConsumption); // 명시적 저장
-
                         return record;
                     })
                     .filter(Objects::nonNull)

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -39,7 +39,6 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final UserQueryService userQueryService;
     private final BudgetCommandService budgetCommandService;
-    private final TotalConsumptionRepository totalConsumptionRepository;
 
     public UserResponse.OAuthLoginResultDTO oAuthLogin(String accessCode, String redirectUrl,HttpServletResponse httpServletResponse) {
         // 1. access token 요청 시 동적 redirectUri 전달
@@ -62,16 +61,9 @@ public class AuthService {
 
         // ✅ 신규 가입자에 대해서만 예산 및 소비 생성
         if (isNewUser) {
-            LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-            LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
+            // Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
             Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
             budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
-
-            totalConsumptionRepository.findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                    .orElseGet(() -> totalConsumptionRepository.save(
-                            TotalConsumptionConverter.toTotalConsumption(user))
-                    );
         }
 
         // 1. User를 기반으로 CustomUserDetails 생성

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
@@ -104,19 +104,9 @@ public class UserCommandServiceImpl implements UserCommandService {
         // 약관 동의 처리
         processAgreements(savedUser, request.getAgreeTerms());
 
-        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
-
-        // 1. Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
+        // Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
         Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
         budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
-
-        // 2. TotalConsumption 조회 or 생성
-        TotalConsumption totalConsumption = totalConsumptionRepository
-                .findByUserAndCreatedAtBetween(user, startOfMonth, endOfMonth)
-                .orElseGet(() -> totalConsumptionRepository.save(
-                        TotalConsumptionConverter.toTotalConsumption(user))
-                );
 
         log.info("로컬 회원가입 완료 - userId: {}", savedUser.getId());
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #150 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 한 달 총 소비 금액 조회 로직 수정
  - 기존에는 집계 테이블(`TotalConsumption`)과 JPA 1차 캐시 때문에 DB에서 데이터를 수정해도 즉시 반영되지 않았음
  - 따라서 `TotalConsumption` 테이블 조회 → `consumption_record` `SUM` 쿼리로 변경
  - DB 수정 사항이 즉시 반영되도록 개선
  - `userId`, `year`, `month` 파라미터 기반 월별 소비 금액 합계 조회

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
- `TotalConsumption` 사용 부분은 최대한 삭제하였는데, 관련 데이터들을 지금 삭제했다가 괜히 꼬일 것 같아서,, 일단은 놔두고 데모데이 끝나고 정리하겠습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1065" height="399" alt="스크린샷 2025-08-19 오후 6 57 48" src="https://github.com/user-attachments/assets/a234105f-5854-45a1-a1f5-2673b051a58f" />
<img width="414" height="208" alt="스크린샷 2025-08-19 오후 6 58 10" src="https://github.com/user-attachments/assets/185450b9-5d1a-46b3-91e0-e7b9da6b438b" />

## 💬 리뷰 요구사항 (선택)
> 금액 오류 부분을 뒤늦게 발견해서 급하게 수정했는데, 성능적으로 총 소비 금액 조회 테이블을 사용하는 것보다 수정한 더 좋은 방법일지는 잘 모르겠습니다! 기존에는 소비 등록, 수정 시 매번 총 소비 금액 테이블에서 변동이 생겼어서 수정한 방법이 더 좋을 것 같기도 하고.. 잘 모르겠네요..
