### PR TITLE
[#152] 🐛Fix: 고정비 예산 반영을 위한 고정비 등록 스케줄러 코드 수정 및 appliedThisMonth 필드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌱 UMC 8th 돈터치 Backend 🌱
 ## 🤑 Introduce
-<img width="1564" height="874" alt="image" src="https://github.com/user-attachments/assets/af8d2a9d-636e-4a9e-97f8-da505bd8d40d" />
+<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/c9ee2c8b-74e9-4162-88a2-c3e651be45f8" />
 
 **돈터치**는 소비 관리 플랫폼으로, 소비 기록과 분석을 중심으로 **예산 관리와 소비 습관 개선**을 지원합니다. SNS 형식의 소비 피드와 랭킹·배지 시스템을 통해 사용자 간 소통과 경쟁을 활성화하며, 가계부·소비 루틴·고정비 관리 등 체계적인 소비 관리 서비스를 제공합니다.
 
@@ -22,7 +22,7 @@
 </p>
 
 ## 🛠 Server Architecture
-<img width="2292" height="1752" alt="Image" src="https://github.com/user-attachments/assets/a1e729b0-4add-4a4f-912e-45ce45ad1eb3" />
+<img width="1955" height="1590" alt="Image" src="https://github.com/user-attachments/assets/849708ec-c94a-4a8b-b481-e94c7448f250" />
 
 ## 👤 Backend Developers
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 <p>
 <img src="https://img.shields.io/badge/springboot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white">
 <img src="https://img.shields.io/badge/Java-007396?style=for-the-badge&logo=openjdk&logoColor=white">
-<img src="https://img.shields.io/badge/MySQL-4479A1?style=for-the-badge&logo=mysql&logoColor=white">
 <img src="https://img.shields.io/badge/JWT-000000?style=for-the-badge&logo=jsonwebtokens&logoColor=white">
+<img src="https://img.shields.io/badge/OAuth2.0-3C3C3D?style=for-the-badge&logo=oauth&logoColor=white">
+<img src="https://img.shields.io/badge/SendGrid-0085CA?style=for-the-badge&logo=sendgrid&logoColor=white">
 <img src="https://img.shields.io/badge/Redis-DC382D?style=for-the-badge&logo=redis&logoColor=white">
 </p>
 <p>
@@ -21,8 +22,9 @@
   <img src="https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=swagger&logoColor=white">
 </p>
 
+
 ## 🛠 Server Architecture
-<img width="1955" height="1590" alt="Image" src="https://github.com/user-attachments/assets/849708ec-c94a-4a8b-b481-e94c7448f250" />
+<img width="1955" height="1540" alt="돈터치 아키텍처" src="https://github.com/user-attachments/assets/acc1630f-5eca-4a2f-aaa8-110ac448bee8" />
 
 ## 👤 Backend Developers
 

--- a/src/main/java/com/server/money_touch/domain/budget/entity/Budget.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/Budget.java
@@ -44,6 +44,10 @@ public class Budget extends BaseEntity {
         this.budgetTotal = budgetTotal;
     }
 
+    public void addTotalBudget(Integer budgetTotal) {
+        this.budgetTotal += budgetTotal;
+    }
+
     public void updateIsFromRoutine(Boolean isFromRoutine) {
         this.isFromRoutine = isFromRoutine;
     }

--- a/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
+++ b/src/main/java/com/server/money_touch/domain/budget/entity/BudgetCategory.java
@@ -27,4 +27,8 @@ public class BudgetCategory extends BaseEntity {
     public void updateAmount(Integer newAmount) {
         this.budgetCategoryMoney = newAmount;
     }
+
+    public void addAmount(Integer newAmount) {
+        this.budgetCategoryMoney += newAmount;
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/budget/repository/budgetCategory/BudgetCategoryRepository.java
+++ b/src/main/java/com/server/money_touch/domain/budget/repository/budgetCategory/BudgetCategoryRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BudgetCategoryRepository extends JpaRepository<BudgetCategory, Long>, BudgetCategoryRepositoryCustom {
     @Query("""
@@ -39,5 +40,7 @@ public interface BudgetCategoryRepository extends JpaRepository<BudgetCategory, 
 
     @Query("SELECT bc FROM BudgetCategory bc JOIN FETCH bc.consumptionCategory WHERE bc.budget = :budget")
     List<BudgetCategory> findByBudgetWithConsumptionCategory(@Param("budget") Budget budget);
+
+    Optional<BudgetCategory> findByBudgetAndConsumptionCategory(Budget budget, ConsumptionCategory category);
 }
 

--- a/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/budget/service/budget/BudgetQueryServiceImpl.java
@@ -89,7 +89,6 @@ public class BudgetQueryServiceImpl implements BudgetQueryService {
     }
 
     // 예산 아이디 및 총 소비 금액 조회
-    @Transactional(readOnly = true)
     @Override
     public BudgetResponse.TotalConsumptionResultDTO findBudgetByIdAndTotalConsumption(Long userId, Integer year, Integer month) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
@@ -101,7 +101,7 @@ public class ConsumptionRecordConverter {
                 .content(fixedConsumption.getFixedConsumptionContent())
                 .memo(fixedConsumption.getFixedConsumptionMemo())
                 .consumeDate(startOfMonth)
-                .isPublic(true) // 가계부에만 등록
+                .isPublic(false) // 가계부에만 등록
                 .isFixed(true) // 고정비 여부
                 .commentCount(0)
                 .wiseCount(0)

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
@@ -1,5 +1,6 @@
 package com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord;
 
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/repository/consumptionRecord/ConsumptionRecordRepository.java
@@ -1,6 +1,5 @@
 package com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord;
 
-import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
@@ -23,6 +23,10 @@ public class FixedConsumption extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String categoryName;
 
+    // ✅ 이번 달 반영 여부
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean appliedThisMonth;
+
     // 고정비-유저 다대일 연관관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -33,5 +37,15 @@ public class FixedConsumption extends BaseEntity {
         this.fixedConsumptionContent = content;
         this.fixedConsumptionMemo = memo;
         this.categoryName = categoryName;
+    }
+
+    // ✅ 이번 달 반영 처리
+    public void markAsApplied() {
+        this.appliedThisMonth = true;
+    }
+
+    // ✅ 초기화 처리 (스케줄러에서 사용)
+    public void resetAppliedFlag() {
+        this.appliedThisMonth = false;
     }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepository.java
@@ -3,6 +3,7 @@ package com.server.money_touch.domain.fixedConsumption.repository;
 import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -13,4 +14,8 @@ public interface FixedConsumptionRepository extends JpaRepository<FixedConsumpti
     List<FixedConsumption> findAllByUser(User user);
 
     Optional<FixedConsumption> findByIdAndUserId(Long id, Long userId);
+
+    @Modifying
+    @Query("UPDATE FixedConsumption fc SET fc.appliedThisMonth = false")
+    void resetAllFlags();
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
@@ -2,7 +2,6 @@ package com.server.money_touch.domain.fixedConsumption.service;
 
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
-import com.server.money_touch.global.validation.annotation.ExistFixedConsumption;
 import com.server.money_touch.global.validation.annotation.ExistUser;
 
 public interface FixedConsumptionCommandService {

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
@@ -1,16 +1,18 @@
 package com.server.money_touch.domain.fixedConsumption.service;
 
+import com.server.money_touch.domain.budget.converter.budgetCategory.BudgetCategoryConverter;
 import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
+import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
 import com.server.money_touch.domain.budget.service.budget.BudgetCommandService;
 import com.server.money_touch.domain.consumptionRecord.converter.consumptionRecord.ConsumptionRecordConverter;
-import com.server.money_touch.domain.consumptionRecord.converter.totalConsumption.TotalConsumptionConverter;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
-import com.server.money_touch.domain.consumptionRecord.entity.TotalConsumption;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
-import com.server.money_touch.domain.consumptionRecord.repository.totalConsumption.TotalConsumptionRepository;
+import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.fixedConsumption.repository.FixedConsumptionRepository;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;
@@ -23,8 +25,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -37,58 +39,104 @@ public class FixedConsumptionSchedulerService {
     private final ConsumptionCategoryRepository consumptionCategoryRepository;
     private final ConsumptionRecordRepository consumptionRecordRepository;
     private final BudgetCommandService budgetCommandService;
+    private final BudgetCategoryRepository budgetCategoryRepository;
+    private final BudgetRepository budgetRepository;
 
     /**
-     * 매월 1일 오전 12시 실행되는 스케줄러 - 고정비를 소비 기록으로 등록
+     * ✅ 매월 1일 00:00 실행되는 단일 스케줄러
+     * 1) 모든 고정비의 appliedThisMonth 플래그를 reset(false)
+     * 2) 각 유저별 고정비를 소비 기록(ConsumptionRecord)에 반영
+     *    - 예산(BudgetCategory, Budget.totalAmount) 에도 금액 반영
+     *
+     * 👉 두 작업을 하나로 합쳐서 실행하므로
+     *    reset 이 완료되지 않으면 등록도 실행되지 않는 구조
      */
-    @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul") // 매월 1일 자정(00:00)
-    public void registerFixedConsumptionsToRecords() {
-        log.info("🕛 [스케줄러] 고정비 소비 기록 등록 작업 시작");
+    @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul") // 매월 1일 00:00
+    @Transactional
+    public void resetAndRegisterFixedConsumptions() {
+        log.info("🕛 [스케줄러] 고정비 reset + 등록 작업 시작");
 
-        List<User> users = userRepository.findAllWithUserDetail();
+        // 1. 플래그 초기화
+        fixedConsumptionRepository.resetAllFlags();
+        log.info("♻️ [스케줄러] 고정비 appliedThisMonth 플래그 초기화 완료");
 
+        // 2. 모든 유저 조회 후, 각 유저 단위로 고정비 반영
+        var users = userRepository.findAllWithUserDetail();
         users.forEach(this::processUserFixedConsumption);
 
-        log.info("🕔 [스케줄러] 고정비 소비 기록 등록 전체 비동기 작업 호출 완료");
+        log.info("✅ [스케줄러] 고정비 reset + 등록 전체 작업 완료");
     }
 
     /**
-     * 사용자 1명에 대한 고정비 소비 기록 등록 (비동기)
+     * ✅ 사용자 단위 고정비 반영 로직 (비동기)
+     * - 이번 달에 아직 반영되지 않은 고정비만 소비 기록으로 생성
+     * - BudgetCategory 및 Budget.totalAmount 업데이트
      */
     @Async("customAsyncExecutor")
     @Transactional
     public void processUserFixedConsumption(User user) {
         try {
+            // 이번 달 1일 00:00
             LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
 
-            // 1. Budget, 기본 ConsumptionCategory 테이블 조회 or 생성
+            // 1. Budget 조회/생성 + 기본 카테고리 생성
             Budget budget = budgetCommandService.createOrFindBudgetForMonth(user);
             budgetCommandService.saveCategoryBudgetsByType(null, user, budget, CategoryType.DEFAULT);
 
-            // 2. 기본 ConsumptionCategory 목록 불러오기 (카테고리 이름 기준 매핑)
+            // 2. 기본 ConsumptionCategory 매핑 (카테고리명 → 엔티티)
             Map<String, ConsumptionCategory> categoryMap = consumptionCategoryRepository
                     .findAllByUserAndBudgetCategoryType(user, CategoryType.DEFAULT)
                     .stream()
                     .collect(Collectors.toMap(ConsumptionCategory::getBudgetCategoryName, c -> c));
 
-            // 3. 고정비 목록을 기반으로 소비 기록 생성 및 저장 + TotalConsumption 반영
-            fixedConsumptionRepository.findAllByUser(user).stream()
-                    .map(fc -> {
-                        String categoryName = fc.getCategoryName();
-                        ConsumptionCategory category = categoryMap.get(categoryName);
-                        if (category == null) {
-                            log.warn("❌ 고정비 카테고리 매핑 실패 - userId: {}, categoryName: {}", user.getId(), categoryName);
-                            return null;
-                        }
+            // ✅ 고정비 총액 누적용
+            AtomicInteger totalFixedAmount = new AtomicInteger(0);
 
-                        // 소비 기록 생성
-                        ConsumptionRecord record = ConsumptionRecordConverter.toConsumptionRecordForFix(user, category, fc, startOfMonth);
-                        return record;
-                    })
-                    .filter(Objects::nonNull)
-                    .forEach(consumptionRecordRepository::save);
+            // 3. 고정비 목록 순회
+            fixedConsumptionRepository.findAllByUser(user).forEach(fc -> {
+                String categoryName = fc.getCategoryName();
+                ConsumptionCategory category = categoryMap.get(categoryName);
 
-            log.info("✅ [스케줄러] 사용자 {} 고정비 소비 기록 등록 완료", user.getId());
+                if (category == null) {
+                    log.warn("❌ 고정비 카테고리 매핑 실패 - userId: {}, categoryName: {}", user.getId(), categoryName);
+                    return;
+                }
+
+                // ✅ 이번 달 이미 반영된 고정비라면 SKIP
+                if (Boolean.TRUE.equals(fc.getAppliedThisMonth())) {
+                    log.info("⚠️ 이미 이번 달 반영된 고정비 - userId={}, content={}", user.getId(), fc.getFixedConsumptionContent());
+                    return;
+                }
+
+                // (1) 소비 기록 생성 및 저장
+                ConsumptionRecord record =
+                        ConsumptionRecordConverter.toConsumptionRecordForFix(user, category, fc, startOfMonth);
+                consumptionRecordRepository.save(record);
+
+                // (2) 예산(BudgetCategory) 반영
+                BudgetCategory budgetCategory = budgetCategoryRepository
+                        .findByBudgetAndConsumptionCategory(budget, category)
+                        .orElseGet(() -> budgetCategoryRepository.save(
+                                BudgetCategoryConverter.toBudgetCategory(budget, category, 0))
+                        );
+
+                budgetCategory.addAmount(fc.getFixedConsumptionAmount());
+                budgetCategoryRepository.save(budgetCategory);
+
+                // (3) 고정비 금액 누적
+                totalFixedAmount.addAndGet(fc.getFixedConsumptionAmount());
+
+                // (4) flag 업데이트 (이번 달 반영 완료)
+                fc.markAsApplied(); // 엔티티 메서드에서 appliedThisMonth = true
+                fixedConsumptionRepository.save(fc);
+            });
+
+            // 4. Budget.totalAmount 갱신
+            budget.addTotalBudget(totalFixedAmount.get());
+            budgetRepository.save(budget);
+
+            log.info("✅ [스케줄러] 사용자 {} 고정비 소비 기록 및 예산 반영 완료 (totalFixedAmount={})",
+                    user.getId(), totalFixedAmount.get());
 
         } catch (Exception e) {
             log.error("❌ [스케줄러] 사용자 {} 고정비 소비 기록 등록 실패: {}", user.getId(), e.getMessage(), e);

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionSchedulerService.java
@@ -12,7 +12,6 @@ import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategor
 import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
 import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
-import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
 import com.server.money_touch.domain.fixedConsumption.repository.FixedConsumptionRepository;
 import com.server.money_touch.domain.user.entity.User;
 import com.server.money_touch.domain.user.repository.user.UserRepository;

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -71,10 +71,10 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         // 3. 예산의 createdMonth로 이번 달 판단
         String createdMonth = budget.getCreatedMonth();
 
-//        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (PESSIMISTIC_WRITE)
-//        if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
-//            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
-//        }
+        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (PESSIMISTIC_WRITE)
+        if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
+            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+        }
 
         // 5. 카테고리 총합 계산
         int totalCategoryBudget = Optional.ofNullable(request.getBudgetList())
@@ -108,9 +108,10 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
                 .collect(Collectors.toList());
         routineAmountRepository.saveAll(routineAmounts);
 
-        // 9. 해시태그 저장
-        if (request.getHashtags() != null) {
+        // 9. 해시태그 저장 (최대 3개까지만)
+        if (request.getHashtags() != null && !request.getHashtags().isEmpty()) {
             List<RoutineHashtag> hashtags = request.getHashtags().stream()
+                    .limit(3) // ✅ 최대 3개 제한
                     .map(tag -> RoutineHashtagConverter.toRoutineHashtag(routine, tag))
                     .collect(Collectors.toList());
             routineHashtagRepository.saveAll(hashtags);

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -26,7 +26,6 @@ import com.server.money_touch.global.apiPayload.exception.handler.ErrorHandler;
 import com.server.money_touch.domain.budget.enums.CategoryType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
@@ -1,11 +1,8 @@
 package com.server.money_touch.domain.routine.service;
 
-import com.server.money_touch.domain.home.dto.HomeResponse;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
 import com.server.money_touch.global.validation.annotation.ExistRoutine;
 import com.server.money_touch.global.validation.annotation.ExistUser;
-
-import java.util.List;
 
 public interface RoutineQueryService {
     // 소비 루틴 존재 여부 검증

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
@@ -29,7 +29,6 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Validated


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #152

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 고정비 등록 시, 매월 1일에 **소비 내역과 예산 모두에 반영**되도록 스케줄러 수정
  - 고정비 엔티티에 `flag(appliedThisMonth)` 필드를 추가하여 이미 소비 기록에 등록된 고정비가 중복으로 반영되는 것을 방지
  - 매월 1일 00:00에 고정비 `appliedThisMonth` 필드 reset 및  예산 생성과 예산 반영, 1일 소비 기록 등록 순차 실행 구조로 변경
- `README`의 서버 아키텍처 수정

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
- 고정비는 이번달에 등록해도, 다음달 예산 및 소비 기록에 반영되기 때문에 아마 8월달에 등록해둔 고정비는 8월 소비내역 및 달력 등에서 보이지 않으실 겁니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
