### PR TITLE
[#154] 🐛Fix: 고정비 등록 시 이번달 1일 소비 기록에 반영되도록 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -4,6 +4,7 @@ import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionReques
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
 import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionCommandService;
 import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionQueryService;
+import com.server.money_touch.domain.fixedConsumption.service.FixedConsumptionSchedulerService;
 import com.server.money_touch.global.apiPayload.ApiResponse;
 import com.server.money_touch.global.apiPayload.code.status.ErrorStatus;
 import com.server.money_touch.global.utils.AuthUtil;
@@ -115,4 +116,13 @@ public class FixedConsumptionController {
         return ApiResponse.onSuccess(response);
     }
 
+    @Operation(
+            summary = "[관리자용] 고정비 갱신 API",
+            description = "이번달 1일 소비 내역에 반영되지 않은 고정비를 수동으로 갱신"
+    )
+    @PostMapping("manual-post")
+    public ApiResponse<String> postFixedConsumptionsByManual(HttpServletRequest servletRequest) {
+        fixedConsumptionCommandService.postFixedConsumptionsByManual();
+        return ApiResponse.onSuccess("고정비 수동 갱신 완료");
+    }
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
@@ -17,6 +17,7 @@ public class FixedConsumptionConverter {
                 .fixedConsumptionAmount(requestDTO.getAmount())
                 .fixedConsumptionContent(requestDTO.getContent())
                 .fixedConsumptionMemo(requestDTO.getMemo())
+                .appliedThisMonth(true)
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandService.java
@@ -14,4 +14,7 @@ public interface FixedConsumptionCommandService {
 
     // 고정비 삭제
     void deleteFixedConsumption(@ExistUser Long userId, Long fixedConsumptionId);
+
+    // 고정비 수동 갱신
+    void postFixedConsumptionsByManual();
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
@@ -1,5 +1,16 @@
 package com.server.money_touch.domain.fixedConsumption.service;
 
+import com.server.money_touch.domain.budget.converter.budgetCategory.BudgetCategoryConverter;
+import com.server.money_touch.domain.budget.entity.Budget;
+import com.server.money_touch.domain.budget.entity.BudgetCategory;
+import com.server.money_touch.domain.budget.enums.CategoryType;
+import com.server.money_touch.domain.budget.repository.budget.BudgetRepository;
+import com.server.money_touch.domain.budget.repository.budgetCategory.BudgetCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.converter.consumptionRecord.ConsumptionRecordConverter;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionCategory;
+import com.server.money_touch.domain.consumptionRecord.entity.ConsumptionRecord;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionCategory.ConsumptionCategoryRepository;
+import com.server.money_touch.domain.consumptionRecord.repository.consumptionRecord.ConsumptionRecordRepository;
 import com.server.money_touch.domain.fixedConsumption.converter.FixedConsumptionConverter;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionRequest;
 import com.server.money_touch.domain.fixedConsumption.dto.FixedConsumptionResponse;
@@ -16,6 +27,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
 
 @Slf4j
 @Validated
@@ -25,26 +43,62 @@ import org.springframework.validation.annotation.Validated;
 public class FixedConsumptionCommandServiceImpl implements FixedConsumptionCommandService {
     private final FixedConsumptionRepository fixedConsumptionRepository;
     private final UserRepository userRepository;
+    private final BudgetRepository budgetRepository;
+    private final BudgetCategoryRepository budgetCategoryRepository;
+    private final ConsumptionCategoryRepository consumptionCategoryRepository;
+    private final ConsumptionRecordRepository consumptionRecordRepository;
 
-    // 고정비 등록
+    /**
+     * ✅ 고정비 등록
+     * - 사용자가 새 고정비를 등록하면 즉시 DB에 저장
+     * - 등록 즉시 이번 달 소비내역 및 예산에도 반영
+     * - appliedThisMonth 플래그로 중복 반영 방지
+     */
     @Transactional
     @Override
     public FixedConsumptionResponse.FixedConsumptionCreateResultDTO saveFixedConsumption(
             Long userId, FixedConsumptionRequest.FixedConsumptionCreateDTO request) {
-        // 카테고리 이름 유효성 검사 - 고정비는 기본 소비 카테고리만 등록 가능
+
+        // 1) 카테고리 이름 유효성 검사 (고정비는 기본 소비 카테고리만 허용)
         if (!DefaultCategoryConstants.DEFAULT_CATEGORY_NAMES.contains(request.getCategoryName())) {
             throw new ErrorHandler(ErrorStatus.CONSUMPTION_CATEGORY_NAME_NOT_FOUND);
         }
 
-        // 사용자 조회
+        // 2) 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 고정비 생성 및 저장
+        // 3) 고정비 생성 및 저장
         FixedConsumption fixedConsumption = FixedConsumptionConverter.toFixedConsumption(user, request);
         fixedConsumptionRepository.save(fixedConsumption);
 
-        log.info("고정비 등록 완료 - userId: {}, fixedConsumptionId: {}", userId, fixedConsumption.getId());
+        // 4) 기본 ConsumptionCategory 매핑 (카테고리명 → 엔티티)
+        Map<String, ConsumptionCategory> categoryMap = consumptionCategoryRepository
+                .findAllByUserAndBudgetCategoryType(user, CategoryType.DEFAULT)
+                .stream()
+                .collect(Collectors.toMap(ConsumptionCategory::getBudgetCategoryName, c -> c));
+
+        String categoryName = fixedConsumption.getCategoryName();
+        ConsumptionCategory category = categoryMap.get(categoryName);
+        if (category == null) {
+            // 기본 카테고리 보정이 실패했거나 이름이 불일치하는 경우
+            log.warn("❌ 고정비 카테고리 매핑 실패 - userId: {}, categoryName: {}", user.getId(), categoryName);
+            return FixedConsumptionConverter.toFixedConsumptionCreateResultDTO(fixedConsumption.getId());
+        }
+
+        // 5) 소비 기록 생성 및 저장 (이번 달 1일 00:00 기준)
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay(); // 이번 달 시작일/예산 식별용 문자열(YYYY-MM)
+        ConsumptionRecord record = ConsumptionRecordConverter
+                .toConsumptionRecordForFix(user, category, fixedConsumption, startOfMonth);
+        consumptionRecordRepository.save(record);
+
+        // 6) flag 업데이트 (이번 달 반영 완료)
+        fixedConsumption.markAsApplied(); // 엔티티 내에서 appliedThisMonth = true
+        fixedConsumptionRepository.save(fixedConsumption);
+
+        log.info("✅ 고정비 등록 완료 - userId: {}, fixedConsumptionId: {}",
+                userId, fixedConsumption.getId());
+
         return FixedConsumptionConverter.toFixedConsumptionCreateResultDTO(fixedConsumption.getId());
     }
 
@@ -93,4 +147,63 @@ public class FixedConsumptionCommandServiceImpl implements FixedConsumptionComma
         fixedConsumptionRepository.delete(fixedConsumption);
         log.info("고정비 삭제 완료 - userId: {}, fixedConsumptionId: {}", userId, fixedConsumptionId);
     }
+
+    // 고정비 수동 갱신
+    /**
+     * ✅ 고정비 수동 갱신 (관리자 수동 실행/즉시 실행용)
+     * - 모든 유저의 고정비를 이번 달 소비내역 + 예산에 반영
+     * - 이미 이번 달에 반영된 고정비는 SKIP
+     */
+    @Override
+    @Transactional
+    public void postFixedConsumptionsByManual() {
+        log.info("🛠 [수동 실행] 고정비 소비 기록 반영 시작");
+
+        // 1) 이번 달 시작일 (1일 00:00)
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+
+        // 2) 모든 유저 조회
+        var users = userRepository.findAllWithUserDetail();
+
+        // 3) 각 유저 단위 처리
+        users.forEach(user -> {
+            log.info("▶️ [수동 실행] 사용자 {} 고정비 반영 시작", user.getId());
+
+            // (a) 기본 ConsumptionCategory 매핑 (카테고리명 → 엔티티)
+            Map<String, ConsumptionCategory> categoryMap = consumptionCategoryRepository
+                    .findAllByUserAndBudgetCategoryType(user, CategoryType.DEFAULT)
+                    .stream()
+                    .collect(Collectors.toMap(ConsumptionCategory::getBudgetCategoryName, c -> c));
+
+            // (b) 고정비 순회
+            fixedConsumptionRepository.findAllByUser(user).forEach(fc -> {
+                String categoryName = fc.getCategoryName();
+                ConsumptionCategory category = categoryMap.get(categoryName);
+
+                if (category == null) {
+                    log.warn("❌ 고정비 카테고리 매핑 실패 - userId: {}, categoryName: {}", user.getId(), categoryName);
+                    return;
+                }
+
+                // ✅ 이번 달 이미 반영된 고정비라면 SKIP
+                if (Boolean.TRUE.equals(fc.getAppliedThisMonth())) {
+                    log.info("⚠️ 이미 이번 달 반영된 고정비 - userId={}, content={}", user.getId(), fc.getFixedConsumptionContent());
+                    return;
+                }
+
+                // (1) 소비 기록 생성 및 저장
+                ConsumptionRecord record = ConsumptionRecordConverter.toConsumptionRecordForFix(user, category, fc, startOfMonth);
+                consumptionRecordRepository.save(record);
+
+                // (2) flag 업데이트
+                fc.markAsApplied();
+                fixedConsumptionRepository.save(fc);
+            });
+
+            log.info("✅ [수동 실행] 사용자 {}", user.getId());
+        });
+
+        log.info("✅ [수동 실행] 전체 사용자 고정비 소비 기록 및 예산 반영 완료 (userCount={})", users.size());
+    }
+
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #154 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 기존에는 이번달에 고정비 등록 시 다음달 1일 소비 기록에 반영되도록 하였는데, pm님 요청에 따라 고정비 등록 시 해당 월의 1일 소비 내역에 바로 반영되도록 수정
  - 총 소비 금액은 변동하지만 카테고리별 예산 금액은 변동 X
  - 고정비 삭제시에는 다음달에 반영 
  
<img width="424" height="289" alt="스크린샷 2025-08-20 오전 11 02 53" src="https://github.com/user-attachments/assets/15f11df0-c7b6-40aa-afee-13f292f8c228" />

- 고정비 수동 갱신 컨트롤러 메서드 추가
  - 이전에 구현한 고정비는 다음달 1일 소비 내역에 추가되기 때문에, 이번달 1일 소비 내역에 반영되도록 수동 갱신 컨트롤러 메서드 추가

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1073" height="628" alt="스크린샷 2025-08-20 오전 11 05 57" src="https://github.com/user-attachments/assets/55c8e66d-69c3-43d1-b71b-a6176b358e63" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
> X
