### PR TITLE
[#156] 🐛Fix: 고정비 등록 시 메모 사항 제거 및 고정비&내 소비 루틴 목록 조회 시 연도, 월 필터링 추가

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/converter/consumptionRecord/ConsumptionRecordConverter.java
@@ -14,25 +14,38 @@ import org.springframework.data.domain.Slice;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public class ConsumptionRecordConverter {
 
     // 일일 소비 기록 시 소비 카테고리 엔티티 생성
-    public static ConsumptionRecord toDailyConsumptionRecord(User user, ConsumptionCategory consumptionCategory, HouseholdConsumptionRequest.DailyConsumptionCreateDTO requestDTO, Boolean isPublic) {
-        return ConsumptionRecord.builder()
+    public static ConsumptionRecord toDailyConsumptionRecord(
+            User user,
+            ConsumptionCategory consumptionCategory,
+            HouseholdConsumptionRequest.DailyConsumptionCreateDTO requestDTO,
+            Boolean isPublic
+    ) {
+        var builder = ConsumptionRecord.builder()
                 .user(user)
                 .consumptionCategory(consumptionCategory)
                 .amount(requestDTO.getAmount())
                 .content(requestDTO.getContent())
-                .memo(requestDTO.getMemo())
                 .consumeDate(requestDTO.getConsumeDate())
                 .isPublic(isPublic) // 일일 소비 기록은 피드 없이 가계부에만 등록
                 .commentCount(0)
                 .wiseCount(0)
                 .wasteCount(0)
-                .viewCount(0)
-                .build();
+                .viewCount(0);
+
+        // memo가 있을 때(공백 제외)만 세팅
+        Optional.ofNullable(requestDTO.getMemo())
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .ifPresent(builder::memo);
+
+        return builder.build();
     }
+
 
     // 소비 기록 응답
     public static ConsumptionRecordResponse.ConsumptionRecordCreateResultDTO toConsumptionRecordCreateResultDTO(Long consumptionRecordId){

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -107,12 +107,14 @@ public class FixedConsumptionController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
     @Parameters({
+            @Parameter(name = "year", description = "조회하려는 소비 연도", example = "2025", required = true),
+            @Parameter(name = "month", description = "조회하려는 소비 월", example = "7", required = true),
             @Parameter(name = "cursorId", description = "커서 (이전 요청의 마지막 cursorId). 첫 요청 시 생략", example = "3", required = false)
     })
     @GetMapping("list")
-    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCursorResultDTO> getFixedConsumptions(@RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {
+    public ApiResponse<FixedConsumptionResponse.FixedConsumptionCursorResultDTO> getFixedConsumptions(@RequestParam(required = true) Integer year, @RequestParam(required = true) Integer month, @RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
-        FixedConsumptionResponse.FixedConsumptionCursorResultDTO response = fixedConsumptionQueryService.getFixedConsumptions(userId, cursorId);
+        FixedConsumptionResponse.FixedConsumptionCursorResultDTO response = fixedConsumptionQueryService.getFixedConsumptions(userId, year, month, cursorId);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/controller/FixedConsumptionController.java
@@ -36,7 +36,7 @@ public class FixedConsumptionController {
 
     @Operation(
             summary = "고정비 등록 API",
-            description = "고정비 등록 API 입니다. 금액, 카테고리, 항목명, 메모를 RequestBody로 입력받아 고정비를 등록합니다."
+            description = "고정비 등록 API 입니다. 금액, 카테고리, 항목명, 메모를 RequestBody로 입력받아 고정비를 등록합니다. 메모가 없다면 RequestBody에 포함하지 않아도 됩니다."
     )
     @ApiSuccessCodeExample(resultClass = FixedConsumptionResponse.FixedConsumptionCreateResultDTO.class)
     @ApiErrorCodeExamples({

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionRequest.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionRequest.java
@@ -29,7 +29,6 @@ public class FixedConsumptionRequest {
         private String content;
 
         @Schema(description = "메모", example = "가족 공유 요금제")
-        @NotNull(message = "메모는 필수입니다.")
         @Size(max = 1000, message = "항목명은 1000자 이하로 입력해주세요.")
         private String memo;
     }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/entity/FixedConsumption.java
@@ -17,7 +17,7 @@ public class FixedConsumption extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String fixedConsumptionContent;
 
-    @Column(nullable = false, length = 1000)
+    @Column(length = 1000)
     private String fixedConsumptionMemo;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryCustom.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface FixedConsumptionRepositoryCustom {
     // 커서 기반 고정비 목록 조회
-    Slice<FixedConsumption> findFixedConsumptionsByCursor(Long userId, Long cursorId, Pageable pageable);
+    Slice<FixedConsumption> findFixedConsumptionsByCursor(Long userId, Long cursorId, int year, int month, Pageable pageable);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/repository/FixedConsumptionRepositoryImpl.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -21,12 +23,22 @@ public class FixedConsumptionRepositoryImpl implements FixedConsumptionRepositor
 
     // 커서 기반 고정비 목록 조회
     @Override
-    public Slice<FixedConsumption> findFixedConsumptionsByCursor(Long userId, Long cursorId, Pageable pageable) {
+    public Slice<FixedConsumption> findFixedConsumptionsByCursor(
+            Long userId, Long cursorId, int year, int month, Pageable pageable) {
+
         BooleanBuilder condition = new BooleanBuilder();
         condition.and(fixed.user.id.eq(userId));
+
+        // 커서 조건
         if (cursorId != null) {
-            condition.and(fixed.id.lt(cursorId)); // id 역순으로 작아야 이후 커서
+            condition.and(fixed.id.lt(cursorId));
         }
+
+        // ✅ 해당 달보다 이후에 생성된 고정비는 보이지 않도록 필터링
+        LocalDate firstDay = LocalDate.of(year, month, 1);
+        LocalDateTime nextMonthStart = firstDay.plusMonths(1).atStartOfDay();
+
+        condition.and(fixed.createdAt.before(nextMonthStart));
 
         int pageSize = pageable.getPageSize();
         List<FixedConsumption> results = queryFactory
@@ -38,7 +50,7 @@ public class FixedConsumptionRepositoryImpl implements FixedConsumptionRepositor
 
         boolean hasNext = results.size() > pageSize;
         if (hasNext) {
-            results.remove(pageSize); // Slice에 반환할 범위까지만 유지
+            results.remove(pageSize);
         }
 
         return new SliceImpl<>(results, pageable, hasNext);

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionCommandServiceImpl.java
@@ -30,8 +30,6 @@ import org.springframework.validation.annotation.Validated;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryService.java
@@ -8,5 +8,5 @@ public interface FixedConsumptionQueryService {
     Boolean existsFixedConsumptionById(Long fixedConsumptionId);
 
     // 고정비 목록 조회 (커서 기반 무한스크롤)
-    FixedConsumptionResponse.FixedConsumptionCursorResultDTO getFixedConsumptions(@ExistUser Long userId, Long cursorId);
+    FixedConsumptionResponse.FixedConsumptionCursorResultDTO getFixedConsumptions(@ExistUser Long userId, Integer year, Integer month, Long cursorId);
 }

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/service/FixedConsumptionQueryServiceImpl.java
@@ -42,37 +42,33 @@ public class FixedConsumptionQueryServiceImpl implements FixedConsumptionQuerySe
      * - 페이지 사이즈는 고정(PAGE_SIZE)
      * - 커서 기반 페이징 방식으로, 마지막 조회된 고정비 ID 이후 데이터를 가져옵니다.
      * - 응답에는 고정비 목록, 다음 커서 ID 및 페이징 정보가 포함됩니다.
-     *
-     * @param userId   사용자 ID
-     * @param cursorId 마지막으로 조회된 고정비 ID (null이면 첫 페이지)
-     * @return FixedConsumptionCursorResultDTO (고정비 목록 + 페이징 정보)
      */
     @Override
-    public FixedConsumptionResponse.FixedConsumptionCursorResultDTO getFixedConsumptions(Long userId, Long cursorId) {
+    public FixedConsumptionResponse.FixedConsumptionCursorResultDTO getFixedConsumptions(
+            Long userId, Integer year, Integer month, Long cursorId) {
+
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(0, PAGE_SIZE);
 
-        // 고정비 목록 조회 (Slice)
+        // 고정비 목록 조회 (Slice) - year, month 추가
         Slice<FixedConsumption> slice = fixedConsumptionRepository
-                .findFixedConsumptionsByCursor(userId, cursorId, pageable);
+                .findFixedConsumptionsByCursor(userId, cursorId, year, month, pageable);
 
-        // 고정비 엔티티 → DTO 변환
         List<FixedConsumptionResponse.FixedConsumptionDetailDTO> content = slice.getContent().stream()
                 .map(FixedConsumptionConverter::toFixedConsumptionDetailDTO)
-                .collect(Collectors.toList());
+                .toList();
 
         // 다음 커서 ID 설정
         Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getFixedConsumptionId();
 
-        log.info("고정비 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, cursorId: {}, nextCursorId: {}", userId, cursorId, nextCursorId);
         return FixedConsumptionConverter.toFixedConsumptionCursorResultDTO(
                 content,
                 slice.hasNext(),
                 nextCursorId,
-                cursorId == null // 첫 페이지 여부
+                cursorId == null
         );
     }
 }

--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -75,18 +75,27 @@ public class RoutineController {
     // 내 소비 루틴 목록 조회
     @Operation(
             summary = "내 소비 루틴 목록 조회 API (커서 기반 무한스크롤)",
-            description = "가계부에서 사용자가 등록한 소비 루틴 목록을 스크롤 형식으로 조회하는 API입니다."
+            description = "가계부에서 사용자가 등록한 소비 루틴 목록을 스크롤 형식으로 조회하는 API입니다. 특정 연도/월별 조회가 가능합니다."
     )
     @ApiErrorCodeExamples({
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR"),
     })
-    @Parameter(name = "cursorId", description = "커서(이전 요청에서 마지막 소비 루틴 아이디), 첫번째 요청일 시에는 파라미터에 포함하지 않아도 됩니다.", example = "10", required = false)
+    @Parameters({
+            @Parameter(name = "cursorId", description = "커서(이전 요청에서 마지막 루틴 ID), 첫 요청 시 생략 가능", example = "10", required = false),
+            @Parameter(name = "year", description = "조회할 연도", example = "2025", required = true),
+            @Parameter(name = "month", description = "조회할 월", example = "7", required = true)
+    })
     @GetMapping("/users")
-    public ApiResponse<RoutineResponse.MyRoutineListDTO> getMyRoutines(@RequestParam(required = false) Long cursorId, HttpServletRequest servletRequest) {
+    public ApiResponse<RoutineResponse.MyRoutineListDTO> getMyRoutines(
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(required = false) Long cursorId,
+            HttpServletRequest servletRequest) {
+
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
-        RoutineResponse.MyRoutineListDTO response = routineQueryService.getMyRoutineList(userId, cursorId);
+        RoutineResponse.MyRoutineListDTO response = routineQueryService.getMyRoutineList(userId, year, month, cursorId);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryCustom.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryCustom.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface RoutineRepositoryCustom {
     // 사용자의 소비 루틴 목록을 커서 기반으로 조회하고, 각 루틴에 연결된 해시태그를 함께 반환
-    Slice<RoutineResponse.RoutineThumbnailDTO> findUserRoutineList(Long userId, Long cursorId, Pageable pageable);
+    Slice<RoutineResponse.RoutineThumbnailDTO> findUserRoutineList(Long userId, Long cursorId, Pageable pageable, int year, int month);
 
     // 전체 소비 루틴 목록을 커서 기반으로 조회, 연결된 해시태그 반환
     Slice<RoutineResponse.RoutineListDTO> findAllRoutines(Long cursorId, Pageable pageable);

--- a/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/repository/routine/RoutineRepositoryImpl.java
@@ -30,8 +30,13 @@ public class RoutineRepositoryImpl implements RoutineRepositoryCustom {
 
     // 사용자의 소비 루틴 목록을 커서 기반으로 조회하고, 각 루틴에 연결된 해시태그를 함께 반환
     @Override
-    public Slice<RoutineResponse.RoutineThumbnailDTO> findUserRoutineList(Long userId, Long cursorId, Pageable pageable) {
-        // 1. 루틴 기본 정보 조회
+    public Slice<RoutineResponse.RoutineThumbnailDTO> findUserRoutineList(
+            Long userId, Long cursorId, Pageable pageable, int year, int month) {
+
+        // 👉 year, month → createdMonth ("YYYY-MM") 변환
+        String targetMonth = String.format("%04d-%02d", year, month);
+
+        // 루틴 기본 정보 조회
         List<RoutineResponse.RoutineThumbnailDTO> routines = queryFactory
                 .select(Projections.fields(RoutineResponse.RoutineThumbnailDTO.class,
                         routine.id.as("routineId"),
@@ -45,22 +50,23 @@ public class RoutineRepositoryImpl implements RoutineRepositoryCustom {
                 .join(routine.user, user)
                 .where(
                         routine.user.id.eq(userId),
+                        routine.createdAt.stringValue().substring(0, 7).eq(targetMonth), // ✅ createdMonth 필터링
                         cursorId != null ? routine.id.lt(cursorId) : null
                 )
-                .orderBy(routine.createdAt.desc(), routine.id.desc()) // 소비 루틴 등록 날짜 내림차순(최신순)
+                .orderBy(routine.createdAt.desc(), routine.id.desc())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        // 2. 다음 페이지 여부 판별
+        // 다음 페이지 여부 판별
         boolean hasNext = routines.size() > pageable.getPageSize();
         if (hasNext) routines.remove(pageable.getPageSize());
 
-        // 3. 루틴 ID 리스트 추출
+        // 루틴 ID 리스트 추출
         List<Long> routineIds = routines.stream()
                 .map(RoutineResponse.RoutineThumbnailDTO::getRoutineId)
                 .toList();
 
-        // 4. 루틴 해시태그 조회 후 Map으로 그룹핑
+        // 루틴 해시태그 조회 후 Map으로 그룹핑
         Map<Long, List<String>> hashtagMap = queryFactory
                 .select(routineHashtag.routine.id, routineHashtag.routineHashtagName)
                 .from(routineHashtag)
@@ -75,11 +81,8 @@ public class RoutineRepositoryImpl implements RoutineRepositoryCustom {
                         )
                 ));
 
-        // 5. 루틴 DTO에 해시태그 추가
-        routines.forEach(r -> {
-            List<String> hashtags = hashtagMap.getOrDefault(r.getRoutineId(), List.of());
-            r.setHashtags(hashtags);
-        });
+        // 루틴 DTO에 해시태그 추가
+        routines.forEach(r -> r.setHashtags(hashtagMap.getOrDefault(r.getRoutineId(), List.of())));
 
         return new SliceImpl<>(routines, pageable, hasNext);
     }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryService.java
@@ -12,7 +12,7 @@ public interface RoutineQueryService {
     RoutineResponse.RoutineDetailDTO getUserRoutineDetail(@ExistUser Long userId, @ExistRoutine Long routineId);
 
     // 내 소비 루틴 목록 조회 (커서 기반 무한스크롤)
-    RoutineResponse.MyRoutineListDTO getMyRoutineList(@ExistUser Long userId, Long cursorId);
+    RoutineResponse.MyRoutineListDTO getMyRoutineList(@ExistUser Long userId, int year, int month, Long cursorId);
 
     // 전체 소비 루틴 목록 조회 (커서 기반 무한스크롤)
     RoutineResponse.AllRoutineListDTO getAllRoutineList(Long cursorId);

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineQueryServiceImpl.java
@@ -75,17 +75,18 @@ public class RoutineQueryServiceImpl implements RoutineQueryService {
 
     // 내 소비 루틴 목록 조회 (커서 기반 무한스크롤)
     @Override
-    public RoutineResponse.MyRoutineListDTO getMyRoutineList(Long userId, Long cursorId) {
-        // 1. Pageable 객체 생성 (페이지 크기 고정, 0페이지부터 시작)
+    public RoutineResponse.MyRoutineListDTO getMyRoutineList(Long userId, int year, int month, Long cursorId) {
         Pageable pageable = PageRequest.of(0, PAGE_SIZE);
 
-        // 2. 커서 기반으로 루틴 목록 조회 (Slice 사용)
-        Slice<RoutineResponse.RoutineThumbnailDTO> slice = routineRepository.findUserRoutineList(userId, cursorId, pageable);
+        // ✅ year, month를 그대로 넘겨줌
+        Slice<RoutineResponse.RoutineThumbnailDTO> slice =
+                routineRepository.findUserRoutineList(userId, cursorId, pageable, year, month);
 
-        // 3. 조회된 루틴 리스트 추출
         List<RoutineResponse.RoutineThumbnailDTO> routineList = slice.getContent();
 
-        log.info("내 소비 루틴 목록 조회(커서 기반 무한스크롤) 완료 - userId: {}, cursorId: {}", userId, cursorId);
+        log.info("내 소비 루틴 목록 조회 완료 - userId={}, cursorId={}, year={}, month={}",
+                userId, cursorId, year, month);
+
         return RoutineConverter.toMyRoutineListDTO(routineList, slice);
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #156 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 고정비 등록 시 메모 필수 입력 조건 제거
- 고정비 및 내 소비 루틴 목록 조회 시 연도/월별 필터링 기능 추가
    - 고정비의 경우, 특정 달(예: 8월)에 등록된 내역은 그 이후 달(예: 9월) 목록에서도 조회 가능

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
```
ALTER TABLE fixed_consumption
MODIFY fixed_consumption_memo VARCHAR(1000) NULL;
```
로컬 DB 콘솔에서 위와 같이 고정비 memo 필드를 NULL 허용으로 바꾸도록 실행 부탁드립니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="724" height="685" alt="스크린샷 2025-08-20 오후 1 49 09" src="https://github.com/user-attachments/assets/3c76ad9d-03d2-4d31-a2f1-c67c58733d6c" />
<img width="718" height="638" alt="스크린샷 2025-08-20 오후 1 49 47" src="https://github.com/user-attachments/assets/cfeba159-cfb7-40a1-8812-f244a687703b" />
<img width="722" height="659" alt="스크린샷 2025-08-20 오후 1 49 56" src="https://github.com/user-attachments/assets/fdacecdb-81e8-4022-b231-d493a3f1aee0" />


## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> 생각해보니까 소비 루틴 등록은 한 달에 1번만 가능하므로 굳이 커서 기반 무한스크롤로 구현할 필요가 없었네요.. 이 부분은 기회가 되면 추후 수정하겠습니다..
