### PR TITLE
🐛Fix : 프로필 이미지 저장 오류 수정및 회원 탈퇴를 위한 엔티티 연관관계 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/badge/entity/Badge.java
+++ b/src/main/java/com/server/money_touch/domain/badge/entity/Badge.java
@@ -24,4 +24,5 @@ public class Badge {
     @Column(nullable = false, length = 100)
     private String description;
 
+
 }

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
@@ -34,6 +34,9 @@ public class ConsumptionCategory extends BaseEntity {
     private User user;
 
     @OneToMany(mappedBy = "consumptionCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionRecord> consumptionRecords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "consumptionCategory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BudgetCategory> budgetCategories = new ArrayList<>();
 
     public void updateCategoryType(CategoryType newType) {

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -24,7 +24,7 @@ public class ConsumptionRecord extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "consumption_category_id", nullable = false)
     private ConsumptionCategory consumptionCategory;
 

--- a/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
+++ b/src/main/java/com/server/money_touch/domain/routine/entity/Routine.java
@@ -6,6 +6,9 @@ import com.server.money_touch.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,4 +45,12 @@ public class Routine extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    // 루틴-루틴해시태그 일대다
+    @OneToMany(mappedBy = "routine", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoutineHashtag> hashtags = new ArrayList<>();
+
+    // 루틴-루틴Amount 일대다
+    @OneToMany(mappedBy = "routine", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoutineAmount> routineAmounts = new ArrayList<>();
 }

--- a/src/main/java/com/server/money_touch/domain/user/entity/User.java
+++ b/src/main/java/com/server/money_touch/domain/user/entity/User.java
@@ -1,13 +1,12 @@
 package com.server.money_touch.domain.user.entity;
 
 
-import com.server.money_touch.domain.badge.entity.Badge;
 import com.server.money_touch.domain.badge.entity.UserBadge;
 import com.server.money_touch.domain.budget.entity.Budget;
-import com.server.money_touch.domain.budget.entity.BudgetCategory;
 import com.server.money_touch.domain.consumptionMbti.entity.ConsumptionMbti;
 import com.server.money_touch.domain.consumptionRecord.entity.*;
 import com.server.money_touch.domain.fixedConsumption.entity.FixedConsumption;
+import com.server.money_touch.domain.home.entity.WiseRankingHistory;
 import com.server.money_touch.domain.notification.entity.Notification;
 import com.server.money_touch.domain.routine.entity.Routine;
 import com.server.money_touch.domain.user.enums.AuthType;
@@ -64,36 +63,45 @@ public class User extends BaseEntity {
     // 회원 삭제를 위한 Cascade 설정
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ConsumptionCategory> categories = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<TotalConsumption> totalConsumption;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Budget> budgets = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Reaction> reactions = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ConsumptionRecord> consumptionRecords = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Notification> notifications = new ArrayList<>();
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionCategory> consumptionCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionMbti> consumptionMbtiList  = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionRecord> consumptionRecords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FixedConsumption> fixedConsumptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Notification> notificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Reaction> reactions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Routine> routines = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TotalConsumption> totalConsumption;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionCategory> categories = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserBadge> badges = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FixedConsumption> fixedConsumptionList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Routine> routines  = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ConsumptionMbti> consumptionMbtiList  = new ArrayList<>();
+    private List<WiseRankingHistory> wiseRankingHistoryList = new ArrayList<>();
 
 }

--- a/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/AuthService.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -53,7 +54,7 @@ public class AuthService {
         boolean isNewUser = false;
 
         if (userQueryService.existsByEmail(email)) {
-            user = userRepository.findByEmail(email).get();
+            user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         } else {
             user = createNewUser(kakaoProfile); // 등록되지않은 회원이면 회원가입
             isNewUser = true;
@@ -89,6 +90,10 @@ public class AuthService {
         String email = kakaoProfile.getKakaoAccount().getEmail();
         String kakaoKey = String.valueOf(kakaoProfile.getId());
         String nickname = kakaoProfile.getKakaoAccount().getProfile().getNickname();
+        String profileImgUrl = Optional.ofNullable(kakaoProfile.getKakaoAccount())
+                .map(k -> k.getProfile())
+                .map(p -> p.getProfileImageUrl())
+                .orElse(null);
 
         // 닉네임 중복 체크
         if (userRepository.existsByNickname(nickname)) {
@@ -99,6 +104,7 @@ public class AuthService {
         User newUser = User.builder()
                 .nickname(nickname)
                 .email(email)
+                .profileImgUrl(profileImgUrl)
                 .authType(AuthType.KAKAO)
                 .role(Role.USER)
                 .build();

--- a/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/user/service/user/UserCommandServiceImpl.java
@@ -91,6 +91,7 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .email(request.getEmail())
                 .authType(AuthType.LOCAL)
                 .role(Role.USER)
+                .profileImgUrl(request.getProfileImgUrl())
                 .nickname(request.getNickname())
                 .build();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#138 

## 📝 작업 내용
1. 프로필 이미지를 추가한후, mbti검사를 진행했을때, mbti이미지가 프로필이미지가 되는 오류가 있어서
프로필 이미지가 있을땐, mbti검사를 진행했어도 프로필이미지가 마이페이지에서 조회되게끔 수정하였습니다.
2. 회원탈퇴를 위해 회원과 일대다관계에 해당 테이블에 대해 CascadeType.ALL을 추가하였습니다.
또한 회원의 자식테이블과 연관된 테이블에 대해서도 일대다 관계에 대해 위 부분을 추가하였습니다.
(*연관관계가 복잡해서 아직 알아차리지 못한부분이 존재할수도있어서 회원탈퇴가 안되는 유저의 경우,
해당 유저의 이메일을 알려달라한후, swagger를 통해 나오는 오류를 통해 해당 엔티티를 수정하는 방식으로 진행중입니다..!)


## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

