### PR TITLE
[#159] 🐛Fix: 타인의 소비 루틴 예산에 반영 시, budgetId 없이 현재 연월의 예산으로 조회하도록 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/server/money_touch/domain/routine/controller/RoutineController.java
@@ -228,18 +228,16 @@ public class RoutineController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
     })
     @Parameters({
-            @Parameter(name = "budgetId", description = "현재 월의 예산 아이디", example = "1", required = true),
             @Parameter(name = "routineId", description = "가져오려는 타인의 소비 루틴 ID", example = "1", required = true)
     })
     @PatchMapping("/list/{routineId}/apply")
     public ApiResponse<String> applyRoutineToBudget(
-            @RequestParam Long budgetId,
             @RequestParam Long routineId,
             @Valid @RequestBody RoutineRequest.ApplyRoutineBudgetDTO request,
             HttpServletRequest servletRequest
     ){
         Long userId = authUtil.getUserIdFromRequest(servletRequest);
-        routineCommandService.applyRoutineToBudget(userId, budgetId, routineId, request);
+        routineCommandService.applyRoutineToBudget(userId, routineId, request);
         return ApiResponse.onSuccess("예산에 성공적으로 반영되었습니다.");
     }
 

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandService.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandService.java
@@ -2,7 +2,6 @@ package com.server.money_touch.domain.routine.service;
 
 import com.server.money_touch.domain.routine.dto.RoutineRequest;
 import com.server.money_touch.domain.routine.dto.RoutineResponse;
-import com.server.money_touch.global.validation.annotation.ExistBudget;
 import com.server.money_touch.global.validation.annotation.ExistRoutine;
 import com.server.money_touch.global.validation.annotation.ExistUser;
 
@@ -11,5 +10,5 @@ public interface RoutineCommandService {
     RoutineResponse.RoutineCreateResultDTO saveRoutineWithRoutineHashtags(@ExistUser Long userId, Long budgetId, RoutineRequest.RoutineCreateDTO request);
 
     // 타인의 소비 루틴을 내 예산에 반영
-    void applyRoutineToBudget(@ExistUser Long userId, @ExistBudget Long budgetId, @ExistRoutine Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request);
+    void applyRoutineToBudget(@ExistUser Long userId, @ExistRoutine Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request);
 }

--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -123,7 +124,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
     // 타인의 소비 루틴을 내 예산에 반영
     @Transactional
     @Override
-    public void applyRoutineToBudget(Long userId, Long budgetId, Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request) {
+    public void applyRoutineToBudget(Long userId, Long routineId, RoutineRequest.ApplyRoutineBudgetDTO request) {
         // 1. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
@@ -136,9 +137,10 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             throw new ErrorHandler(ErrorStatus.ROUTINE_PREVIEW_NOT_ALLOWED);
         }
 
-        // 3. 예산 조회
-        Budget budget = budgetRepository.findById(budgetId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUDGET_NOT_FOUND));
+        // 3. 이번 달 예산 조회
+        String currentMonth = LocalDate.now().withDayOfMonth(1).toString().substring(0, 7); // "2025-08"
+        Budget budget = budgetRepository.findByUserIdAndCreatedMonth(userId, currentMonth)
+                .orElseThrow(() -> new ErrorHandler(BUDGET_NOT_EXIST));
 
         if (!budget.getUser().getId().equals(userId)) {
             throw new ErrorHandler(ErrorStatus.BUDGE_UNAUTHORIZED);
@@ -210,6 +212,6 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
                     }
                 });
 
-        log.info("타인의 소비 루틴을 내 예산에 반영 완료 - userId: {}, budgetId: {}, routineId: {}", userId, budgetId, routineId);
+        log.info("타인의 소비 루틴을 내 예산에 반영 완료 - userId: {}, currentMonth: {}, routineId: {}", userId, currentMonth, routineId);
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #159 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 기존에는 타인의 소비 루틴을 내 예산에 반영 시, 쿼리 파라미터로 `budgetId`를 받도록 하였는데, 서비스 로직에서 직접 현재 연월의 예산을 조회하여 반영되도록 수정

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="483" height="534" alt="스크린샷 2025-08-20 오후 10 50 14" src="https://github.com/user-attachments/assets/a362ddc1-4344-4866-a532-7bf8cd3cbe6b" />


## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
