### PR TITLE
[#156] 🐛Fix: 고정비 목록 조회 응답값 content 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/converter/FixedConsumptionConverter.java
@@ -16,7 +16,12 @@ public class FixedConsumptionConverter {
                 .categoryName(requestDTO.getCategoryName())
                 .fixedConsumptionAmount(requestDTO.getAmount())
                 .fixedConsumptionContent(requestDTO.getContent())
-                .fixedConsumptionMemo(requestDTO.getMemo())
+                // ✅ 메모가 비어 있으면 null 로 처리
+                .fixedConsumptionMemo(
+                        (requestDTO.getMemo() == null || requestDTO.getMemo().isBlank())
+                                ? null
+                                : requestDTO.getMemo()
+                )
                 .appliedThisMonth(true)
                 .build();
     }
@@ -34,7 +39,7 @@ public class FixedConsumptionConverter {
                 .fixedConsumptionId(entity.getId())
                 .categoryName(entity.getCategoryName())
                 .amount(entity.getFixedConsumptionAmount())
-                .memo(entity.getFixedConsumptionMemo())
+                .content(entity.getFixedConsumptionContent())
                 .build();
     }
 

--- a/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionResponse.java
+++ b/src/main/java/com/server/money_touch/domain/fixedConsumption/dto/FixedConsumptionResponse.java
@@ -61,7 +61,7 @@ public class FixedConsumptionResponse {
         @Schema(description = "고정비 금액", example = "23000")
         private Integer amount;
 
-        @Schema(description = "메모", example = "가족 공유 요금제")
-        private String memo;
+        @Schema(description = "항목명", example = "가족 공유 요금제")
+        private String content;
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #156

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 고정비 목록 조회 시 응답값에 memo가 아닌 content를 반환하도록 수정
- 고정비 등록 시 memo 사항이 없으면 null로 저장되도록 수정

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  X

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
