### PR TITLE
🐛Fix: 소비와 ConsumptionRecord 연관관계 단방향으로 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionCategory.java
@@ -33,8 +33,8 @@ public class ConsumptionCategory extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "consumptionCategory", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ConsumptionRecord> consumptionRecords = new ArrayList<>();
+//    @OneToMany(mappedBy = "consumptionCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<ConsumptionRecord> consumptionRecords = new ArrayList<>();
 
     @OneToMany(mappedBy = "consumptionCategory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BudgetCategory> budgetCategories = new ArrayList<>();

--- a/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
+++ b/src/main/java/com/server/money_touch/domain/consumptionRecord/entity/ConsumptionRecord.java
@@ -24,7 +24,7 @@ public class ConsumptionRecord extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "consumption_category_id", nullable = false)
     private ConsumptionCategory consumptionCategory;
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> 급한 사항이라 이슈는 파지 못했습니다.

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- `ConsumptionCategory`에 설정된 `ConsumptionRecord`와의 양방향 연관관계 주석처리
- `ConsumptionRecord`에서 `ConsumptionCategory`에 설정된 cascade 삭제

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
- 일일 소비 기록 삭제 시 관련 소비 카테고리까지 함께 삭제되는 문제가 발생하여, 급히 연관관계 매핑을 수정했습니다. 다만 이 과정에서 회원 탈퇴 시 처리 로직에 영향이 있을 수 있으며, cascade 설정 변경으로 인해 회원 탈퇴 기능이 정상적으로 동작하지 않을 것 같습니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
