### PR TITLE
Chore: userId가 1인 경우는 소비 루틴 등록 및 반영 횟수 제한 풀도록 수정

### DIFF
--- a/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/server/money_touch/domain/routine/service/RoutineCommandServiceImpl.java
@@ -71,9 +71,11 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         // 3. 예산의 createdMonth로 이번 달 판단
         String createdMonth = budget.getCreatedMonth();
 
-        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (PESSIMISTIC_WRITE)
-        if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
-            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+        // 4. 이번 달 동일 예산에 대한 루틴 존재 여부 확인 (단, userId=1 은 중복 허용)
+        if (!userId.equals(1L)) { // ✅ userId=1일 때는 중복 검사 스킵
+            if (routineRepository.findForUpdateByUserAndBudgetAndMonth(userId, budgetId, createdMonth).isPresent()) {
+                throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+            }
         }
 
         // 5. 카테고리 총합 계산
@@ -92,14 +94,14 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
         }
 
         // 7. 루틴 저장
-        //   - 동시에 같은 (user, budget, createdMonth) 조합이 저장되는 경쟁 상황 방지
-        //   - 유니크 제약 위반 발생 시 DataIntegrityViolationException을 잡아 예외 변환
         Routine routine = RoutineConverter.toRoutine(user, budget, request, createdMonth);
         try {
             routineRepository.save(routine);
         } catch (Exception e) {
             // 혹시 경쟁 상황으로 유니크 제약 위반 시
-            throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+            if (!userId.equals(1L)) { // ✅ userId=1일 때는 예외 변환하지 않음
+                throw new ErrorHandler(ROUTINE_ALREADY_EXIST);
+            }
         }
 
         // 8. RoutineAmount 저장
@@ -146,8 +148,8 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
             throw new ErrorHandler(ErrorStatus.BUDGE_UNAUTHORIZED);
         }
 
-        // 이미 루틴 적용된 예산이라면 예외
-        if (Boolean.TRUE.equals(budget.getIsFromRoutine())) {
+        // 이미 루틴 적용된 예산이라면 예외 (단, userId=1은 중복 허용)
+        if (!userId.equals(1L) && Boolean.TRUE.equals(budget.getIsFromRoutine())) {
             throw new ErrorHandler(ErrorStatus.ROUTINE_ALREADY_APPLIED);
         }
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> ex) #이슈번호

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- userId가 1인 경우(시연용 계정)는 소비 루틴 등록 및 반영 횟수 제한 풀도록 수정
- 소비루틴 중복 저장 트리거 수정
  ```
  DROP TRIGGER IF EXISTS routine_no_dup;
  DELIMITER //
  CREATE TRIGGER routine_no_dup
      BEFORE INSERT ON routine
      FOR EACH ROW
  BEGIN
      -- user_id = 1 은 중복 허용
      IF CAST(NEW.user_id AS SIGNED) <> 1 THEN
          IF EXISTS (
              SELECT 1 FROM routine r
              WHERE r.user_id = NEW.user_id
                AND r.budget_id = NEW.budget_id
                AND r.created_month = NEW.created_month
              LIMIT 1
          ) THEN
              SIGNAL SQLSTATE '45000'
                  SET MESSAGE_TEXT = 'Duplicate entry not allowed';
          END IF;
      END IF;
  END;
  //
  DELIMITER ;
  ``` 


## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  PR 머지되면 시연용 계정으로 로그인 하셔서 소비 루틴 등록&타인의 소비 루틴 예산 반영 부분 테스트 꼭 부탁드립니다..

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
